### PR TITLE
Add gradle caching

### DIFF
--- a/.github/workflows/phgv2_ci.yml
+++ b/.github/workflows/phgv2_ci.yml
@@ -26,10 +26,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - name: Setup Gradle  # This sets up caching to make builds faster
-        uses: gradle/gradle-build-action@v2
+          cache: 'gradle'
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build --no-daemon
       - name: Run Kover XML report
         run: ./gradlew koverXMLReport
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/phgv2_ci.yml
+++ b/.github/workflows/phgv2_ci.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      - name: Setup Gradle  # This sets up caching to make builds faster
+        uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
         run: ./gradlew clean build
       - name: Run Kover XML report

--- a/.github/workflows/run_deploy_on_merge.yml
+++ b/.github/workflows/run_deploy_on_merge.yml
@@ -107,6 +107,9 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      - name: Setup Gradle  # This sets up caching to make builds faster
+        uses: gradle/gradle-build-action@v2
+
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 

--- a/.github/workflows/run_deploy_on_merge.yml
+++ b/.github/workflows/run_deploy_on_merge.yml
@@ -106,15 +106,13 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-
-      - name: Setup Gradle  # This sets up caching to make builds faster
-        uses: gradle/gradle-build-action@v2
+          cache: 'gradle'
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
       - name: Build PHGv2
-        run: ./gradlew clean build
+        run: ./gradlew clean build --no-daemon
 
       - name: Get matching release
         uses: cardinalby/git-get-release-action@1.2.4


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

These updates to the Github actions allow for faster builds as it caches the gradle runtimes when java is started..  This should update if build.gradle is updated.  Shaved about 2 minutes off of the build(out of 5 currently).  The big slowdown now is the conda env creation which will be faster once we use the mamba resolver.


## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Updated workflows to be faster on GitHub actions.
```