### PR TITLE
Change reference flag to "reference-file"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To populate that database
 
 ## Build VCF data
 ./phg create-ranges --reference-file Ref.fa --gff my.gff --boundary gene --pad 500 -o /path/to/bed/file.bed
-./phg align-assemblies --gff anchors.gff --reference Ref.fa -a assembliesList.txt --total-threads 20 --in-parallel 4 -o /path/for/generatedFiles
+./phg align-assemblies --gff anchors.gff --reference-file Ref.fa -a assembliesList.txt --total-threads 20 --in-parallel 4 -o /path/for/generatedFiles
 ./phg agc-compress --db-path /path/to/dbs --reference-file /my/ref.fasta --fasta-list /my/assemblyFastaList.txt 
 ./phg create-ref-vcf --bed /my/bed/file.bed --reference-file /my/ref.fasta --reference-url https://url-for-ref --reference-name B73 --output-dir /path/to/vcfs
 ./phg create-maf-vcf --db-path /path/to/dbs --bed /my/bed/file.bed --reference-file /my/ref.fasta --maf-dir /my/maf/files -o /path/to/vcfs

--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/AlignAssemblies.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/AlignAssemblies.kt
@@ -64,7 +64,7 @@ class AlignAssemblies : CliktCommand(help="Align assemblies using anchorwave") {
         .default("")
         .validate {
             require(it.isNotBlank()) {
-                "--reference must not be blank"
+                "--reference-file must not be blank"
             }
         }
 

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/AlignAssembliesTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/AlignAssembliesTest.kt
@@ -22,7 +22,7 @@ class AlignAssembliesTest {
 
         // Test missing gff file parameter,
         val resultMissingGff =
-            alignAssemblies.test(" --reference ${TestExtension.testRefFasta} -a ${TestExtension.smallseqAssembliesListFile} -o ${TestExtension.tempDir}")
+            alignAssemblies.test(" --reference-file ${TestExtension.testRefFasta} -a ${TestExtension.smallseqAssembliesListFile} -o ${TestExtension.tempDir}")
         assertEquals(resultMissingGff.statusCode, 1)
         assertEquals(
             "Usage: align-assemblies [<options>]\n" +
@@ -37,12 +37,12 @@ class AlignAssembliesTest {
         assertEquals(
             "Usage: align-assemblies [<options>]\n" +
                     "\n" +
-                    "Error: invalid value for --reference: --reference must not be blank\n", resultMissingRef.output
+                    "Error: invalid value for --reference-file: --reference-file must not be blank\n", resultMissingRef.output
         )
 
         // Test missing assemblies list file parameter,
         val resultMissingAssembliesList =
-            alignAssemblies.test(" --gff ${TestExtension.smallseqAnchorsGffFile} --reference ${TestExtension.smallseqRefFile} -o ${TestExtension.tempDir}")
+            alignAssemblies.test(" --gff ${TestExtension.smallseqAnchorsGffFile} --reference-file ${TestExtension.smallseqRefFile} -o ${TestExtension.tempDir}")
         assertEquals(resultMissingAssembliesList.statusCode, 1)
         assertEquals(
             "Usage: align-assemblies [<options>]\n" +
@@ -52,7 +52,7 @@ class AlignAssembliesTest {
 
         // Test missing output directory parameter
         val resultMissingOutputDir =
-            alignAssemblies.test(" --gff ${TestExtension.smallseqAnchorsGffFile} --reference ${TestExtension.smallseqRefFile} -a ${TestExtension.smallseqAssembliesListFile}")
+            alignAssemblies.test(" --gff ${TestExtension.smallseqAnchorsGffFile} --reference-file ${TestExtension.smallseqRefFile} -a ${TestExtension.smallseqAssembliesListFile}")
         assertEquals(resultMissingOutputDir.statusCode, 1)
         assertEquals(
             "Usage: align-assemblies [<options>]\n" +
@@ -72,7 +72,7 @@ class AlignAssembliesTest {
         val alignAssemblies = AlignAssemblies()
 
         val result = alignAssemblies.test(
-            "--gff ${TestExtension.smallseqAnchorsGffFile} --reference ${TestExtension.smallseqRefFile} " +
+            "--gff ${TestExtension.smallseqAnchorsGffFile} --reference-file ${TestExtension.smallseqRefFile} " +
                     "-a ${TestExtension.smallseqAssembliesListFile} -o ${TestExtension.tempDir}"
         )
 

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/FullPipelineIT.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/FullPipelineIT.kt
@@ -87,7 +87,7 @@ class FullPipelineIT {
         //Run Anchorwave
         val alignAssemblies = AlignAssemblies()
         val alignAssembliesResult = alignAssemblies.test(
-            "--gff ${TestExtension.smallseqAnchorsGffFile} --reference ${TestExtension.smallseqRefFile} " +
+            "--gff ${TestExtension.smallseqAnchorsGffFile} --reference-file ${TestExtension.smallseqRefFile} " +
                     "-a ${TestExtension.smallseqAssembliesListFile} -o ${TestExtension.testMafDir}"
         )
         println(alignAssembliesResult.output)


### PR DESCRIPTION
## Description
Hot fix to change the `reference` flag to `reference-file`. Also removes unused imports.



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note

```