### PR TITLE
Do not merge this! Testing Actions for automatic Conda build + upload

### DIFF
--- a/.github/workflows/test_set_variable.yml
+++ b/.github/workflows/test_set_variable.yml
@@ -1,0 +1,28 @@
+name: Test Set Variable
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-set-variable:
+    runs-on: ubuntu-latest
+    steps:
+      # Update repository variables for Conda package
+      - name: Fake data for testing
+        run: |
+          export VERSION=1.2.3.4
+          export RELEASE=1.2
+          touch PHGv2-v${{ env.RELEASE }}.tar
+      - uses: action-pack/set-variable@v1
+        with:
+          name: 'PHG2_VERSION'
+          value: '${{ env.VERSION }}'
+          token: ${{secrets.PHGV2CD}}
+      - name: Calculate MD5 of package
+        run: |
+          export PHG2_VERSION_MD5=$(md5sum PHGv2-v${{ env.RELEASE }}.tar)
+      - uses: action-pack/set-variable@v1
+        with:
+          name: 'PHG2_VERSION_MD5'
+          value: '${{ env.PHG2_VERSION_MD5 }}'
+          token: ${{secrets.PHGV2CD}}

--- a/.github/workflows/test_set_variable.yml
+++ b/.github/workflows/test_set_variable.yml
@@ -1,7 +1,11 @@
 name: Test Set Variable
 
+# Hacky solution: https://stackoverflow.com/a/76439748
+# Annoying that I have to do this for GitHub to show any action not on main
+
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   test-set-variable:


### PR DESCRIPTION
Source: https://stackoverflow.com/a/76439748

I'm working on getting automatic Conda package builds working. As part of that I want to make sure I'm setting some repository variables correctly with my GitHub Actions.

However, GitHub will not show any action in the web UI that isn't already on `main`. Triggering my action via a PR is a quick workaround so that it appears and remains on the website for triggering manually via `workflow_dispatch`.