### PR TITLE
bug fix creating intergenic regions between nearby genic regions

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/CreateRanges.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/CreateRanges.kt
@@ -23,7 +23,6 @@ import java.io.File
 /**
  * Data class to hold the information needed to output a BedRecord.
  */
-// TODO when we generate these objects, need to go from 1-based to 0-based indexing
 data class BedRecord(val contig: String, val start : Int, val end: Int, val name: String, val score : Int, val strand: String )
 
 /**

--- a/src/main/kotlin/net/maizegenetics/phgv2/utils/GeneralUtilities.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/utils/GeneralUtilities.kt
@@ -93,10 +93,6 @@ fun createFlankingList(geneRange:RangeMap<Position,String>, numFlanking:Int, ref
             var flankingStart = findFlankingStartPos(geneRange,data, numFlanking)
             val flankingEnd = findFlankingEndPos(geneRange,data, numFlanking, chrLen)
 
-            if(chr == "Chr01"){
-            println("${data.lowerEndpoint()} - ${data.upperEndpoint()}")
-            println("Corrected to $flankingStart - $flankingEnd")
-            }
             flankingRange.put(Range.closed( flankingStart, flankingEnd), range.value)
 
         }

--- a/src/main/kotlin/net/maizegenetics/phgv2/utils/GeneralUtilities.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/utils/GeneralUtilities.kt
@@ -6,6 +6,7 @@ import com.google.common.collect.RangeMap
 import com.google.common.collect.TreeRangeMap
 import org.apache.logging.log4j.LogManager
 import java.io.BufferedInputStream
+import kotlin.math.ceil
 
 private val myLogger = LogManager.getLogger("net.maizegenetics.phgv2.utils.GeneralUtilities")
 
@@ -91,6 +92,11 @@ fun createFlankingList(geneRange:RangeMap<Position,String>, numFlanking:Int, ref
             // Find new start/end positions with specified number of flanking, add this position to the map
             var flankingStart = findFlankingStartPos(geneRange,data, numFlanking)
             val flankingEnd = findFlankingEndPos(geneRange,data, numFlanking, chrLen)
+
+            if(chr == "Chr01"){
+            println("${data.lowerEndpoint()} - ${data.upperEndpoint()}")
+            println("Corrected to $flankingStart - $flankingEnd")
+            }
             flankingRange.put(Range.closed( flankingStart, flankingEnd), range.value)
 
         }
@@ -138,7 +144,7 @@ fun findFlankingStartPos(geneRange:RangeMap<Position,String>, data:Range<Positio
         // the last overlap should be the closest in position to the current range start
         val prevEnd = overlapsStart.get(overlapsStart.size-1).key.upperEndpoint().position
         val newFlankNum = curStart-prevEnd // flanking is adjusted to be half on either side of the previous range
-        val newLowerInt = (curStart - newFlankNum/2)+1 // want start to be 1 past the end of the previous range
+        val newLowerInt = (curStart - ceil(newFlankNum / 2.0).toInt() )+1 // want start to be 1 past the end of the previous range
         newLowerPos = Position(chrom,newLowerInt)
     } else {
         val newLowerInt = if (curStart - numFlanking < 1)  1 else curStart - numFlanking

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/CreateRangesTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/CreateRangesTest.kt
@@ -51,16 +51,16 @@ class CreateRangesTest {
         val obsIdList02 = cr.idMinMaxBounds(NucSeqIO(refGood).readAll(), genes, "cds")
 
         val obsIdList01Keys = obsIdList01.asMapOfRanges().keys
-        var key1 = Range.closed(Position("chr1",34616),Position("chr1",40204))
-        var key2 = Range.closed(Position("chr1",41213),Position("chr1",46762))
+        var key1 = Range.closed(Position("chr1",34617),Position("chr1",40204))
+        var key2 = Range.closed(Position("chr1",41214),Position("chr1",46762))
 
         assertEquals(2, obsIdList01.asMapOfRanges().keys.size)
         assertTrue(obsIdList01Keys.contains(key1))
         assertTrue(obsIdList01Keys.contains(key2))
 
         val obsIdList02Keys = obsIdList02.asMapOfRanges().keys
-        key1 = Range.closed(Position("chr1",34721),Position("chr1",38366))
-        key2 = Range.closed(Position("chr1",41526),Position("chr1",45913))
+        key1 = Range.closed(Position("chr1",34722),Position("chr1",38366))
+        key2 = Range.closed(Position("chr1",41527),Position("chr1",45913))
         assertEquals(2, obsIdList02.asMapOfRanges().keys.size)
         assertTrue(obsIdList02Keys.contains(key1))
         assertTrue(obsIdList02Keys.contains(key2))
@@ -70,8 +70,8 @@ class CreateRangesTest {
         // Run again with the good reference fasta - chrom names match those in gff
         val obsIdList03 = cr.idMinMaxBounds(NucSeqIO(refGood).readAll(),genes, "gene")
         val obsIdList03Keys = obsIdList03.asMapOfRanges().keys
-        key1 = Range.closed(Position("chr1",34616),Position("chr1",40204))
-        key2 = Range.closed(Position("chr1",41213),Position("chr1",46762))
+        key1 = Range.closed(Position("chr1",34617),Position("chr1",40204))
+        key2 = Range.closed(Position("chr1",41214),Position("chr1",46762))
         assertEquals(2, obsIdList03.asMapOfRanges().keys.size)
         assertTrue(obsIdList03Keys.contains(key1))
         assertTrue(obsIdList03Keys.contains(key2))
@@ -86,13 +86,13 @@ class CreateRangesTest {
         // Run again with the good reference fasta - chrom names match those in gff
         val obsIdList03Flanking = createFlankingList(obsIdList03, 100,NucSeqIO(refGood).readAll())
         val obsIdList03FlankingKeys = obsIdList03Flanking.asMapOfRanges().keys
-        key1 = Range.closed(Position("chr1",34516),Position("chr1",40304))
-        key2 = Range.closed(Position("chr1",41113),Position("chr1",46862))
+        key1 = Range.closed(Position("chr1",34517),Position("chr1",40304))
+        key2 = Range.closed(Position("chr1",41114),Position("chr1",46862))
         assertEquals(2, obsIdList03.asMapOfRanges().keys.size)
         assertTrue(obsIdList03FlankingKeys.contains(key1))
         assertTrue(obsIdList03FlankingKeys.contains(key2))
 
-
+        // Note: this is where we switch from 1-based indexing to 0-based indexing
         val obsBedList01 = cr.generateBedRecords(obsIdList01)
         val obsBedList02 = cr.generateBedRecords(obsIdList01)
 
@@ -164,6 +164,28 @@ class CreateRangesTest {
         val lines = File(outputFileName).bufferedReader().readLines()
         assertEquals("chr1\t34616\t40204\tZm00001eb000010\t0\t.", lines[0])
         assertEquals("chr1\t41213\t46762\tZm00001eb000020\t0\t.", lines[1])
+    }
+
+    @Test
+    fun testFileOutputWithOverlappingRegions() {
+        val testGffPath = "src/test/resources/net/maizegenetics/phgv2/cli/zm_b73v5_test.gff3.gz"
+        val ref = "src/test/resources/net/maizegenetics/phgv2/cli/RefChr.fa"
+        val command = CreateRanges()
+
+        val outputFileName = "${tempDir}test_extrapadding.bed"
+
+        val result = command.test("--gff $testGffPath --reference-file $ref --pad 600 --output $outputFileName")
+        assertEquals(result.statusCode, 0)
+        assertEquals(command.gff, testGffPath)
+        assertEquals(command.boundary, "gene")
+        assertEquals(command.pad, 600)
+        assertEquals(command.output, outputFileName)
+
+        val lines = File(outputFileName).bufferedReader().readLines()
+        assertEquals("chr1\t0\t34016\tintergenic_chr1:0-34016\t0\t+", lines[0])
+        assertEquals("chr1\t34016\t40709\tZm00001eb000010\t0\t.", lines[1])
+        assertEquals("chr1\t40709\t47362\tZm00001eb000020\t0\t.", lines[2])
+        assertEquals("chr1\t47362\t55000\tintergenic_chr1:47362-55000\t0\t+", lines[3])
     }
 
     @Test
@@ -295,7 +317,7 @@ class CreateRangesTest {
         gene = Position("chr1",922);
         geneLowerFlank = flankingGeneMap.getEntry(gene)!!.key.lowerEndpoint().position;
         geneUpperFlank = flankingGeneMap.getEntry(gene)!!.key.upperEndpoint().position;
-        assertEquals(841,geneLowerFlank);
+        assertEquals(840,geneLowerFlank);
         assertEquals(1051, geneUpperFlank);
 
         // gene4


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

Fixed a bug in create-ref-ranges. Conversion between 1-based indexing in gffs and 0-based indexing in beds was inconsistent and resulted in 1-2 bp gaps between genic reference ranges when overlap in padding bases was corrected. The inconsistency has been corrected - guava Ranges are assumed to use gff-style indexing, and BedRecords use bed-style indexing. 

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Fixed a bug causing 1-2 bp intergenic regions to be created when padding in genic regions overlapped.
```