### PR TITLE
Documentation - fix `create-ref-vcf` typo

### DIFF
--- a/docs/build_and_load.md
+++ b/docs/build_and_load.md
@@ -725,7 +725,7 @@ phg create-ref-vcf \
     --bed output/ref_ranges.bed \
     --reference-file data/Ref.fa \
     --reference-name B73 \
-    -o output/vcf_files
+    --db-path vcf_dbs
 ```
 
 2. Create hVCF and gVCF data from assembly alignments against reference
@@ -751,18 +751,15 @@ data:
 #### `create-ref-vcf` inputs
 The `create-ref-vcf` command requires the following inputs:
 
-* `--bed` - A BED file containing ordered reference ranges (_see
+* `--bed` - a BED file containing ordered reference ranges (_see
   the [**"Create reference ranges"**](#create-reference-ranges) section for further details_). This
   is used to define the positional information of the VCF.
-* `--reference-file` - Reference FASTA genome used for creating
+* `--reference-file` - reference FASTA genome used for creating
   MD5 hashes of sequence information guided by reference range
   positional data from the BED file used in the `--bed` parameter.
-* `--reference-name` - The name of the reference sample
-* `-db-path` - Output directory for the VCF data.
+* `--reference-name` - the name of the reference sample.
+* `--db-path` - path to PHG database directory for VCF storage.
 
-> [!WARNING]
-> The directory that you specify in the output (`-o`) section must
-> be an existing directory.
 
 > [!NOTE]
 > Optionally, `create-ref-vcf` can also use another parameter, 


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description
This PR fixes a parameter typo for the `create-ref-vcf` command in the "Build and Load" documentation:
* Originally was `-o`, but now is `--db-path`



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Fix parameter typo for `create-ref-vcf` command in "Build and Load" documentation
```