### PR TITLE
added warning regarding trailing spaces in --assemblies file in docs/build_and_load.md

### DIFF
--- a/docs/build_and_load.md
+++ b/docs/build_and_load.md
@@ -569,6 +569,10 @@ default values are calculated by the software based on the system processor and 
 
 
 > [!WARNING]
+> Make sure there are no trailing spaces in the text file containing 
+> the list of assembly genomes (`--assemblies`).
+
+> [!WARNING]
 > The directory that you specify in the output (`-o`) section must
 > be an existing directory.
 


### PR DESCRIPTION
## Description

Hi @lynnjo , I have added a warning regarding trailing spaces in --assemblies file in the detailed walkthrough at `docs/build_and_load.md`. This caused errors while running phg `align-assemblies`.

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

```release-note
Added warning regarding trailing spaces in --assemblies file in the detailed walkthrough
```