### PR TITLE
trim assembly name from align-assemblies assembly list

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/AlignAssemblies.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/AlignAssemblies.kt
@@ -133,6 +133,7 @@ class AlignAssemblies : CliktCommand(help = "Align assemblies using AnchorWave")
         createCDSfromRefData(referenceFile, gff, cdsFasta, outputDir)
 
         // create list of assemblies to align from the assemblies file
+        // exclude blank lines
         val assembliesList = File(assemblies).readLines().filter { it.isNotBlank() }
 
         // run minimap2 for ref to refcds
@@ -418,8 +419,9 @@ class AlignAssemblies : CliktCommand(help = "Align assemblies using AnchorWave")
                 assemblies.forEach { asmFile ->
 
                     // Column names were checked for validity above
+                    // used ".trim()" to remove trailing whitespace from the file name
                     myLogger.info("Adding: $asmFile for processing")
-                    inputChannel.send(InputChannelData(refFasta, asmFile, outputDir, gffFile, refSamOutFile, runsAndThreads.first, runsAndThreads.second))
+                    inputChannel.send(InputChannelData(refFasta, asmFile.trim(), outputDir, gffFile, refSamOutFile, runsAndThreads.first, runsAndThreads.second))
                 }
                 myLogger.info("Done Adding data to the inputChannel:")
                 inputChannel.close() // Need to close this here to show the workers that it is done adding more data

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/AlignAssembliesTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/AlignAssembliesTest.kt
@@ -132,6 +132,36 @@ class AlignAssembliesTest {
     }
 
     @Test
+    fun testAssembliesWithTrailingSpaces() {
+        // This test verifies the code handles an assembly list that
+        // has blank spaces following the assembly name on the line.
+        // ".trim()" was added when reading the assembly list to handle
+        // this case.  This test is to verify that the code works.
+        val assemblyList = TestExtension.smallseqAssembliesListFile
+        val assemblyListWithSpaces = "${TestExtension.tempDir}assembliesListWithSpaces.txt"
+        // create a new list by taking assembliList values and adding a space to the end of each line,
+        // writing the new list to assemblyListWithSpaces
+        File(assemblyList).forEachLine {
+            File(assemblyListWithSpaces).appendText("$it \n")
+        }
+
+        // run assemblies, verify we have a failure
+        val alignAssemblies = AlignAssemblies()
+
+        val result = alignAssemblies.test(
+            "--gff ${TestExtension.smallseqAnchorsGffFile} --reference-file ${TestExtension.smallseqRefFile} " +
+                    "-a $assemblyListWithSpaces -o ${TestExtension.tempDir} --total-threads 1 --in-parallel 1"
+        )
+
+        val lineAMAF = TestExtension.tempDir + "LineA.maf"
+        assertTrue(File(lineAMAF).exists(), "File $lineAMAF does not exist")
+
+        val lineBMAF = TestExtension.tempDir + "LineB.maf"
+        assertTrue(File(lineBMAF).exists(), "File $lineBMAF does not exist")
+
+    }
+
+    @Test
     fun testRunningAlignAssemblies() {
 
         // phg align-assemblies --gff /workdir/tmc46/AlignAssemblies/smallSeq_data/anchors.gff


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
align-assemblies now checks for trailing whitespace after the assembly file names in the file list
```