### PR TITLE
Add PHG version retrieval method

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/Phg.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/Phg.kt
@@ -10,6 +10,7 @@ import net.maizegenetics.phgv2.pathing.BuildKmerIndex
 import net.maizegenetics.phgv2.pathing.FindPaths
 import net.maizegenetics.phgv2.pathing.MapKmers
 import net.maizegenetics.phgv2.utils.getBufferedReader
+import net.maizegenetics.phgv2.utils.phgVersion
 import net.maizegenetics.phgv2.utils.setupDebugLogging
 
 class Phg : CliktCommand() {
@@ -21,32 +22,7 @@ class Phg : CliktCommand() {
             helpFormatter = { MordantHelpFormatter(it, showRequiredTag = true) }
         }
 
-        // get version from version.properties file
-        var majorVersion = 0
-        var minorVersion = 0
-        var patchVersion = 0
-        var buildNumber = 0
-
-        // Try to get the version.properties file from the jar file
-        // If that fails, try to get it from the current working directory
-        val reader = try {
-            Phg::class.java.getResourceAsStream("/version.properties").bufferedReader()
-        } catch (e: Exception) {
-            val path = System.getProperty("user.dir")
-            println("Getting version from: ${path}/version.properties")
-            getBufferedReader("${path}/version.properties")
-        }
-
-        reader.readLines().forEach {
-            val (key, value) = it.split("=")
-            when (key) {
-                "majorVersion" -> majorVersion = value.toInt()
-                "minorVersion" -> minorVersion = value.toInt()
-                "patchVersion" -> patchVersion = value.toInt()
-                "buildNumber" -> buildNumber = value.toInt()
-            }
-        }
-        val version = "$majorVersion.$minorVersion.$patchVersion.$buildNumber"
+        val version = phgVersion()
         versionOption(version)
     }
 

--- a/src/main/kotlin/net/maizegenetics/phgv2/utils/GeneralUtilities.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/utils/GeneralUtilities.kt
@@ -4,6 +4,7 @@ import biokotlin.seq.NucSeq
 import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
 import com.google.common.collect.TreeRangeMap
+import net.maizegenetics.phgv2.cli.Phg
 import org.apache.logging.log4j.LogManager
 import java.io.BufferedInputStream
 import kotlin.math.ceil
@@ -180,3 +181,60 @@ fun findFlankingEndPos(geneRange:RangeMap<Position,String>, data:Range<Position>
     }
     return newUpperPos
 }
+
+/**
+ * Retrieves PHGv2 version information from the `version.properties`
+ * file.
+ *
+ * The version is composed of four components: major version, minor
+ * version, patch version, and build number.
+ *
+ * The function first attempts to read the `version.properties` file
+ * from within the JAR file, using the resource stream. If that fails,
+ * it will try to read the file from the current working directory.
+ *
+ * The `version.properties` file is expected to have the following
+ * format:
+ *
+ * ```
+ * majorVersion=<integer>
+ * minorVersion=<integer>
+ * patchVersion=<integer>
+ * buildNumber=<integer>
+ * ```
+ *
+ * @return A `String` representing the full version in the format "major.minor.patch.build".
+ *         For example, "1.0.0.123".
+ *
+ * @throws RuntimeException if the `version.properties` file cannot be found or is incorrectly formatted.
+ */
+fun phgVersion(): String {
+    // get version from version.properties file
+    var majorVersion = 0
+    var minorVersion = 0
+    var patchVersion = 0
+    var buildNumber = 0
+
+    // Try to get the version.properties file from the jar file
+    // If that fails, try to get it from the current working directory
+    val reader = try {
+        Phg::class.java.getResourceAsStream("/version.properties").bufferedReader()
+    } catch (e: Exception) {
+        val path = System.getProperty("user.dir")
+        println("Getting version from: ${path}/version.properties")
+        getBufferedReader("${path}/version.properties")
+    }
+
+    reader.readLines().forEach {
+        val (key, value) = it.split("=")
+        when (key) {
+            "majorVersion" -> majorVersion = value.toInt()
+            "minorVersion" -> minorVersion = value.toInt()
+            "patchVersion" -> patchVersion = value.toInt()
+            "buildNumber" -> buildNumber = value.toInt()
+        }
+    }
+
+    return("$majorVersion.$minorVersion.$patchVersion.$buildNumber")
+}
+

--- a/src/test/kotlin/net/maizegenetics/phgv2/utils/GeneralUtilitiesTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/utils/GeneralUtilitiesTest.kt
@@ -1,0 +1,73 @@
+package net.maizegenetics.phgv2.utils
+
+import net.maizegenetics.phgv2.cli.TestExtension
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.FileNotFoundException
+import java.nio.file.Path
+import kotlin.test.assertEquals
+
+@ExtendWith(TestExtension::class)
+class GeneralUtilitiesTest {
+
+    /**
+     * Helper function to create a temporary version.properties file for testing
+     */
+    private fun createVersionPropertiesFile(directory: Path, content: String) {
+        val versionFile = File(directory.toFile(), "version.properties")
+        versionFile.writeText(content)
+    }
+
+    @Test
+    fun testWorkingVersionProperties(@TempDir tempDir: Path) {
+        // Simulate the file in the current working directory
+        createVersionPropertiesFile(tempDir, """
+            majorVersion=2
+            minorVersion=3
+            patchVersion=4
+            buildNumber=234
+        """.trimIndent())
+
+        System.setProperty("user.dir", tempDir.toFile().absolutePath)
+
+        val version = phgVersion()
+
+        assertEquals("2.3.4.234", version)
+    }
+
+    @Test
+    fun testMalformedVersionProperties(@TempDir tempDir: Path) {
+        // Create a malformed version.properties file
+        createVersionPropertiesFile(tempDir, """
+            majorVersion=2
+            minorVersion=wrongFormat
+            patchVersion=4
+            buildNumber=234
+        """.trimIndent())
+
+        System.setProperty("user.dir", tempDir.toFile().absolutePath)
+
+        val exception = assertThrows<NumberFormatException> {
+            phgVersion()
+        }
+
+        Assertions.assertNotNull(exception)
+    }
+
+    @Test
+    fun testMissingVersionPropertiesFile() {
+        // Simulate the absence of the version.properties file in both locations
+        System.setProperty("user.dir", "/non/existent/directory")
+
+        val exception = assertThrows<FileNotFoundException> {
+            phgVersion()
+        }
+
+        assertEquals("/non/existent/directory/version.properties (No such file or directory)", exception.message)
+    }
+
+}


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description
This PR moves the methods used to generate the version string in the `Phg` class `init` block into a new function. The rationale for this is to provide an easier means of calling the version number of the PHGv2 instance loaded into an R session via the rPHG2 package.


## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Add PHG version retrieval method
```