### PR TITLE
Create fasta from hvcf fix duplicate entries

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/CreateFastaFromHvcf.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/CreateFastaFromHvcf.kt
@@ -140,7 +140,7 @@ class CreateFastaFromHvcf : CliktCommand( help = "Create a FASTA file from a h.v
         if(fastaType == FastaType.composite)
             writeCompositeSequence(outputWriter, haplotypeSequences)
         else if(fastaType == FastaType.haplotype) {
-            writeHaplotypeSequence(outputWriter, haplotypeSequences)
+            writeHaplotypeSequence(outputWriter, haplotypeSequences.toSet())
         }
     }
 
@@ -262,7 +262,7 @@ class CreateFastaFromHvcf : CliktCommand( help = "Create a FASTA file from a h.v
      * Function to output haplotype sequences to a fasta file.  Here each haplotype is exported as its own fasta record without concatenating things together.
      * This is almost identical to how fastas were exported in the original version of the pipeline.
      */
-    fun writeHaplotypeSequence(outputFileWriter: BufferedWriter, haplotypeSequences: List<HaplotypeSequence>, exportFullIdLine : Boolean = true) {
+    fun writeHaplotypeSequence(outputFileWriter: BufferedWriter, haplotypeSequences: Set<HaplotypeSequence>, exportFullIdLine : Boolean = true) {
         for(hapSeq in haplotypeSequences) {
             outputFileWriter.write(">${hapSeq.id}")
             if(exportFullIdLine) {

--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/CreateFastaFromHvcf.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/CreateFastaFromHvcf.kt
@@ -140,7 +140,7 @@ class CreateFastaFromHvcf : CliktCommand( help = "Create a FASTA file from a h.v
         if(fastaType == FastaType.composite)
             writeCompositeSequence(outputWriter, haplotypeSequences)
         else if(fastaType == FastaType.haplotype) {
-            writeHaplotypeSequence(outputWriter, haplotypeSequences.toSet())
+            writeHaplotypeSequence(outputWriter, haplotypeSequences)
         }
     }
 
@@ -262,8 +262,9 @@ class CreateFastaFromHvcf : CliktCommand( help = "Create a FASTA file from a h.v
      * Function to output haplotype sequences to a fasta file.  Here each haplotype is exported as its own fasta record without concatenating things together.
      * This is almost identical to how fastas were exported in the original version of the pipeline.
      */
-    fun writeHaplotypeSequence(outputFileWriter: BufferedWriter, haplotypeSequences: Set<HaplotypeSequence>, exportFullIdLine : Boolean = true) {
-        for(hapSeq in haplotypeSequences) {
+    fun writeHaplotypeSequence(outputFileWriter: BufferedWriter, haplotypeSequences: List<HaplotypeSequence>, exportFullIdLine : Boolean = true) {
+        // Make this a set to remove duplicates
+        for(hapSeq in haplotypeSequences.toSet()) {
             outputFileWriter.write(">${hapSeq.id}")
             if(exportFullIdLine) {
                 outputFileWriter.write(" Ref_Range_Id=${hapSeq.refRangeId} " +

--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/CreateFastaFromHvcf.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/CreateFastaFromHvcf.kt
@@ -263,8 +263,8 @@ class CreateFastaFromHvcf : CliktCommand( help = "Create a FASTA file from a h.v
      * This is almost identical to how fastas were exported in the original version of the pipeline.
      */
     fun writeHaplotypeSequence(outputFileWriter: BufferedWriter, haplotypeSequences: List<HaplotypeSequence>, exportFullIdLine : Boolean = true) {
-        // Make this a set to remove duplicates
-        for(hapSeq in haplotypeSequences.toSet()) {
+        // Make this a set to remove duplicates.  A LinkedHashSet to maintain the order
+        for(hapSeq in haplotypeSequences.toCollection(LinkedHashSet())) {
             outputFileWriter.write(">${hapSeq.id}")
             if(exportFullIdLine) {
                 outputFileWriter.write(" Ref_Range_Id=${hapSeq.refRangeId} " +

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/CreateFastaFromHvcfTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/CreateFastaFromHvcfTest.kt
@@ -227,13 +227,7 @@ class CreateFastaFromHvcfTest {
             HaplotypeSequence(getChecksumForString(seqs[4]), seqs[4], getChecksumForString(seqs[4]), "2", 301, 600, listOf(Pair(Position("2", 301), Position("1", 600))))
         )
 
-
-        // toSet() applied here to remove the duplicate
-        // This is how the function is called in the source code
-        // Because writeHaplotypeSequence is called from the same parent function as writeCompositeSequence,
-        // and the latter needs the duplicates to remain,
-        // the haplotypeSequences are passed in as a set, so the duplicate is removed
-
+        // Write the haplotype fasta
         BufferedWriter(FileWriter(outputFile)).use { writer ->
             createFastaFromHvcf.writeHaplotypeSequence(writer, haplotypeSequences)
         }


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

 When creating a haplotype fasta from an hvcf file, there should not be duplicates.  Fixed the code so that resulting fasta files will contain no more than 1 instance of a haplotype with its sequence.



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
CreateFastaFromHvcf now correctly contains a single instance of a haplotype sequence when when creating haplotype fastas.
```