### PR TITLE
Fix "Quick Start" parameters

### DIFF
--- a/docs/build_and_load.md
+++ b/docs/build_and_load.md
@@ -54,7 +54,7 @@ In this document, we will discuss the steps needed to:
     phg align-assemblies \
         --gff anchors.gff \
         --reference-file /my/updated/ref.fasta \
-        --assemblies /updated/assemblies_list.txt \
+        --assembly-file-list /updated/assemblies_list.txt \
         -o /path/for/generated_files
     ```
 
@@ -755,7 +755,8 @@ file contains 6 columns of information:
 
     * Same contig/chromosome IDs
     * Coordinates are [**0-based, inclusive/exclusive**](https://tidyomics.com/blog/2018/12/09/2018-12-09-the-devil-0-and-1-coordinate-system-in-genomics/)
-    * Coordinates do not exceed contig boundaries
+    * Coordinates do **not** exceed contig boundaries
+    * Coordinates do **not** overlap
     * Contains the first three BED columns:
         + `1` - Sequence name
         + `2` - Start position (bp)


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description
This PR:
* Fixes a parameter typo found in the `align-assemblies` command in the "Quick Start" section
* Adds another warning found in one of the call-outs in the "Create Ranges" section (didn't forget about this, @zrm22)



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note

```