### PR TITLE
Removing the option to have map-kmers hit multiple reference ranges.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     implementation("org.jetbrains.lets-plot:lets-plot-kotlin-jvm:4.7.0")
     implementation("org.jetbrains.lets-plot:lets-plot-image-export:4.3.0")
     implementation("org.jetbrains.lets-plot:lets-plot-batik:4.3.0")
-    implementation("org.biokotlin:biokotlin:0.19")
+    implementation("org.biokotlin:biokotlin:0.21")
     implementation("com.github.ajalt.clikt:clikt:4.2.0")
 
     implementation("com.github.samtools:htsjdk:4.0.1")

--- a/docs/imputation.md
+++ b/docs/imputation.md
@@ -413,19 +413,12 @@ The Map Kmers  command can take the following optional parameters:
 |-----------------------------------------|---------------------------------------------------------------------------------------------------------------------|---------------|
 | `--threads`                             | Number of threads used for mapping                                                                                  | `5`           |
 | `--min-proportion-of-max-count`         | Minimum proportion of the maximum kmer count for a read to be considered a match                                    | `1.0`         |
-| `--limit-single-ref-range`              | Flag.  Enable this option to force reads to only count haplotypeIds from kmers coming from a single Reference Range | false         |
 | `--min-proportion-same-reference-range` | Minimum proportion of the read that must align to the same reference range                                          | `0.9`         |
 
 
 !!! note
-    If `--limit-single-ref-range` is set to true, reads that map to 
-    multiple reference ranges will be discarded based on the 
-    `--min-proportion-same-reference-range` parameter. If left off 
-    or set to false, `--min-proportion-same-reference-range` will be 
-    ignored. By limiting reads to only map to a single reference 
-    range, your imputation accuracy could improve at the expense 
-    of not using as many reads. You will need to test this out for 
-    your specific use case.
+    We have removed `--limit-single-ref-range` as it introduces a very high error rate.
+    By default `map-kmers` will only use kmers from a single reference range for each read.
 
 
 

--- a/docs/imputation.md
+++ b/docs/imputation.md
@@ -418,7 +418,7 @@ The Map Kmers  command can take the following optional parameters:
 
 !!! note
     We have removed `--limit-single-ref-range` as it introduces a very high error rate.
-    By default `map-kmers` will only use kmers from a single reference range for each read.
+    `map-kmers` will only use kmers from a single reference range for each read.
 
 
 

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/AlignmentUtils.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/AlignmentUtils.kt
@@ -42,7 +42,7 @@ class AlignmentUtils {
             outputDir: String,
             numThreads: Int = 5,
             minProportionOfMaxCount: Double = 1.0,
-            limitSingleRefRange: Boolean = false,
+            limitSingleRefRange: Boolean = true,
             minSameReferenceRange: Double = 0.9,
         ) {
             myLogger.info("Loading in Kmer Index Map")
@@ -177,7 +177,7 @@ class AlignmentUtils {
             graph: HaplotypeGraph,
             numThreads: Int = 5,
             minProportionOfMaxCount: Double = 1.0,
-            limitSingleRefRange: Boolean = false,
+            limitSingleRefRange: Boolean = true,
             minSameReferenceRange: Double = 0.9,
         ): Map<List<String>, Int> {
             val fastqFiles = Pair(keyFileRecord.file1, keyFileRecord.file2)
@@ -287,7 +287,7 @@ class AlignmentUtils {
             refrangeToBitSet: Map<Int, BitSet>,
             rangeToHapidIndexMap: Map<Int, Map<String, Int>>,
             minProportionOfMaxCount: Double = 1.0,
-            limitSingleRefRange: Boolean = false,
+            limitSingleRefRange: Boolean = true,
             minSameReferenceRange: Double = 0.9
         ) {
             for (pairOfReads in reads) {
@@ -337,7 +337,7 @@ class AlignmentUtils {
             refrangeToBitSet: Map<Int, BitSet>,
             rangeToHapidIndexMap: Map<Int, Map<String, Int>>,
             minProportionOfMaxCount: Double = 1.0,
-            limitSingleRefRange: Boolean = false,
+            limitSingleRefRange: Boolean = true,
             minSameReferenceRange: Double = 0.9
         ): Pair<Map<Int, Set<String>>, Map<Int, Set<String>>> {
             val result1 = readToHapIdSetMultipleRefRanges(
@@ -376,7 +376,7 @@ class AlignmentUtils {
             refrangeToBitSet: Map<Int, BitSet>,
             rangeToHapidIndexMap: Map<Int, Map<String, Int>>,
             minProportionOfMaxCount: Double = 1.0,
-            limitSingleRefRange: Boolean = false,
+            limitSingleRefRange: Boolean = true,
             minSameReferenceRange: Double = 0.9
         ): Map<Int, Set<String>> {
             //generate kmer hash from the read

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/MapKmers.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/MapKmers.kt
@@ -93,20 +93,13 @@ class MapKmers : CliktCommand(help="Map Kmers to the pangenome reference") {
         .double()
         .default(1.0)
 
-    val limitSingleRefRange by option(help = "Enable this option to force reads to only count haplotypeIds from kmers coming from a single Reference Range.")
-        .flag(default = false)
 
-    val minProportionSameReferenceRange by option(help = "Minimum proportion of the read that must align to the same reference range. This option is not used unless -limit-single-ref-range is used.  Default is 0.9.")
+    val minProportionSameReferenceRange by option(help = "Minimum proportion of the read that must align to the same reference range.  Default is 0.9.")
         .double()
         .default(0.9)
 
 
     override fun run() {
-        //check to see if minProportionSameReferenceRange is being used without limitSingleRefRange
-        if(!limitSingleRefRange) {
-            myLogger.info("The --min-proportion-same-reference-range option is not used unless --limit-single-ref-range is used.  " +
-                    "Ignoring --min-proportion-same-reference-range.")
-        }
 
         myLogger.info("Begin mapping reads to the pangenome kmer index.")
         //loop through all files in hvcfDir and create a list of hvcf files
@@ -119,6 +112,6 @@ class MapKmers : CliktCommand(help="Map Kmers to the pangenome reference") {
 
         //create a HaplotypeGraph from the list of hvcf files
         val graph = HaplotypeGraph(hvcfFiles)
-        AlignmentUtils.alignReadsToHaplotypes(graph, kmerIndexFilename, readInputFiles.getReadFiles(), outputDir, threads, minProportionOfMaxCount, limitSingleRefRange, minProportionSameReferenceRange)
+        AlignmentUtils.alignReadsToHaplotypes(graph, kmerIndexFilename, readInputFiles.getReadFiles(), outputDir, threads, minProportionOfMaxCount, true, minProportionSameReferenceRange)
     }
 }


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

Removing option for users to have Kmers map to different reference ranges.  This is identical to how things were done in previous versions of PHGv2

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Removing option to map reads to multiple reference ranges.
```