### PR TITLE
Remove optional parameters quick start

### DIFF
--- a/docs/build_and_load.md
+++ b/docs/build_and_load.md
@@ -25,9 +25,7 @@ In this document, we will discuss the steps needed to:
 * Initialize TileDB instances:
     ```shell
     phg initdb \
-        --db-path /path/to/dbs \
-        --gvcf-anchor-gap 1000000 \
-        --hvcf-anchor-gap 1000
+        --db-path /path/to/dbs
     ```
 
 * Update FASTA headers with sample information:

--- a/docs/build_and_load.md
+++ b/docs/build_and_load.md
@@ -83,7 +83,7 @@ In this document, we will discuss the steps needed to:
 * Load data into DBs
     ```shell
     phg load-vcf \
-        --vcf /path/to/vcf_files \
+        --vcf-dir /path/to/vcf_files \
         --db-path /path/to/dbs \
         --threads 10
     ```

--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/Phg.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/Phg.kt
@@ -5,11 +5,9 @@ import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.output.MordantHelpFormatter
 import com.github.ajalt.clikt.parameters.options.versionOption
-import net.maizegenetics.phgv2.agc.PrepareAssemblies
 import net.maizegenetics.phgv2.pathing.BuildKmerIndex
 import net.maizegenetics.phgv2.pathing.FindPaths
 import net.maizegenetics.phgv2.pathing.MapKmers
-import net.maizegenetics.phgv2.utils.getBufferedReader
 import net.maizegenetics.phgv2.utils.phgVersion
 import net.maizegenetics.phgv2.utils.setupDebugLogging
 

--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/PrepareAssemblies.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/PrepareAssemblies.kt
@@ -1,4 +1,4 @@
-package net.maizegenetics.phgv2.agc
+package net.maizegenetics.phgv2.cli
 
 import biokotlin.util.bufferedReader
 import com.github.ajalt.clikt.core.CliktCommand

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/PrepareAssembliesTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/PrepareAssembliesTest.kt
@@ -1,7 +1,6 @@
-package net.maizegenetics.phgv2.agc
+package net.maizegenetics.phgv2.cli
 
 import com.github.ajalt.clikt.testing.test
-import net.maizegenetics.phgv2.cli.TestExtension
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

- Removed parameters --gvcf-anchor-gap and --hvcf-anchor-gap from command initdb in the "Quick Start" since they are optional
- Corrected --vcf-dir parameter for the load-vcf command in the "Quick Start"
- Moved PrepareAssemblies from package agc to cli



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Corrected Building and Loading Quick Start Instructions
```