### PR TITLE
Reverting github actions to go back to 22.04

### DIFF
--- a/.github/workflows/deploy_project_site.yml
+++ b/.github/workflows/deploy_project_site.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Configure Git Credentials

--- a/.github/workflows/phgv2_ci.yml
+++ b/.github/workflows/phgv2_ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test:
     name: PHGv2 CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       checks: write # See: https://github.com/mikepenz/action-junit-report/issues/23#issuecomment-1412597753

--- a/.github/workflows/run_deploy_on_merge.yml
+++ b/.github/workflows/run_deploy_on_merge.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   check-app-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       app_changed: ${{ steps.check_app_changes.outputs.app_changed }}
     steps:
@@ -41,7 +41,7 @@ jobs:
           fi
 
   build-and-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: check-app-changes
     if: ${{ needs.check-app-changes.outputs.app_changed == 'true' }}
     steps:


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

Updating GitHub actions to use a specific build of ubuntu 22.04


## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note

```