### PR TITLE
new tiledb-vcf-java jar compiled with ubuntu:latest

### DIFF
--- a/.github/workflows/deploy_project_site.yml
+++ b/.github/workflows/deploy_project_site.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Configure Git Credentials

--- a/.github/workflows/phgv2_ci.yml
+++ b/.github/workflows/phgv2_ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test:
     name: PHGv2 CI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write # See: https://github.com/mikepenz/action-junit-report/issues/23#issuecomment-1412597753

--- a/.github/workflows/run_deploy_on_merge.yml
+++ b/.github/workflows/run_deploy_on_merge.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   check-app-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       app_changed: ${{ steps.check_app_changes.outputs.app_changed }}
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,8 @@ dependencies {
 
     // Use these jar file when compiling for Linux
     // Keep the Mac Intel and Mac ARM jar inclusions commented out
-    implementation(files("repo/tiledb-vcf-java-0.25.2.jar"))
+    //implementation(files("repo/tiledb-vcf-java-0.25.2.jar"))
+    implementation(files("repo/tiledb-vcf-java-0.37.0-1-g03553439.jar")) // added 2024-01-08 based on ubuntua:latest
     implementation(files("repo/tiledb-java-0.19.6-SNAPSHOT.jar"))
 
     // Use these jar files when compiling for Mac with Intel chip

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,8 +66,7 @@ dependencies {
 
     // Use these jar file when compiling for Linux
     // Keep the Mac Intel and Mac ARM jar inclusions commented out
-    //implementation(files("repo/tiledb-vcf-java-0.25.2.jar"))
-    implementation(files("repo/tiledb-vcf-java-0.37.0-1-g03553439.jar")) // added 2024-01-08 based on ubuntua:latest
+    implementation(files("repo/tiledb-vcf-java-0.37.0-1-g03553439.jar")) // added 2024-01-08 based on TileDB VCF 0.37.0 build
     implementation(files("repo/tiledb-java-0.19.6-SNAPSHOT.jar"))
 
     // Use these jar files when compiling for Mac with Intel chip


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

Included a new tiledb-vcf-java jar file built with ubuntu:latest.  ALso updates the github/workflow scripts to use ubuntu:latest



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
- updated tiledb-vcf-java jar file built from ubuntu:latest
-->

```release-note
Updated tiledb-vcf-java jar file to load 37, CI build scripts updated to ubuntu:latest
```