### PR TITLE
Add fix to Conda "-p" parameter variable

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/utils/SeqUtils.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/utils/SeqUtils.kt
@@ -273,7 +273,7 @@ fun buildAgcCommandFromList(dbPath:String, agcCmd:String, ranges:List<String>, c
     check(File(agcFile).exists()) { "File assemblies.agc does not exist in folder $dbPath- please send a valid path that indicates the parent folder for your assemblies.agc compressed file." }
 
     val command = mutableListOf<String>()
-    val commandPrefix = if (condaEnvPrefix.isNotBlank()) arrayOf("conda","run","-p","phgv2-conda") else arrayOf("conda","run","-n","phgv2-conda")
+    val commandPrefix = if (condaEnvPrefix.isNotBlank()) arrayOf("conda","run","-p", condaEnvPrefix) else arrayOf("conda","run","-n","phgv2-conda")
     val commandData = arrayOf("agc",agcCmd,agcFile)
     command.addAll(commandPrefix)
     command.addAll(commandData)


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description
* Fixes Conda prefix parameter (`-p`) to pass actual prefix variable instead of "baked-in" `"phgv2-conda"` string
  + Identified in [this discussion](https://github.com/maize-genetics/phg_v2/discussions/290#discussion-8061719).



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Fix Conda prefix parameter bug in `buildAgcCommandFromList()`
```