### PR TITLE
Add checks for empty sets

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/BuildSplineKnots.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/BuildSplineKnots.kt
@@ -38,7 +38,7 @@ class BuildSplineKnots: CliktCommand(help = "Build Spline Knot points from gVCFs
         logCommand(this)
 
         myLogger.info("Building Spline Knots from $vcfType files in $vcfDir")
-        val contigSet = contigList.split(",").map { it.trim() }.toSet()
+        val contigSet = contigList.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toSet()
 
         val splineKnotLookup = SplineUtils.buildSplineKnots(vcfDir, vcfType, minIndelLength, maxNumPointsPerChrom, contigSet)
 

--- a/src/test/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/BuildSplineKnotsTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/BuildSplineKnotsTest.kt
@@ -3,6 +3,7 @@ package net.maizegenetics.phgv2.pathing.ropebwt
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import com.github.ajalt.clikt.testing.test
+import org.junit.jupiter.api.Assertions.assertTrue
 
 
 class BuildSplineKnotsTest {
@@ -19,5 +20,44 @@ class BuildSplineKnotsTest {
         assertEquals(1, noOutputFile.statusCode)
         assertEquals("Usage: build-spline-knots [<options>]\n\n" +
                 "Error: missing option --output-file\n", noOutputFile.stderr)
+    }
+
+    fun oldSplitter(chrList: String): Set<String> =
+        chrList.split(",").map(String::trim).toSet()
+    fun newSplitter(chrList: String): Set<String> =
+        chrList.split(",").map(String::trim).filter(String::isNotEmpty).toSet()
+
+    @Test
+    fun testContigListProcessing() {
+        // Test prior set behavior
+        val emptyString = ""
+        val problematicSet = oldSplitter(emptyString)
+
+        // This set should not be empty, which causes the issue
+        assertEquals(1, problematicSet.size)
+        assertTrue(problematicSet.contains(""))
+
+        // Test new set creator - verify `""` gets converted to an empty set
+        val fixSet = newSplitter(emptyString)
+        assertEquals(0, fixSet.size)
+
+        // Test with actual contigs (A)
+        val nonEmptyStringA = "chr1,chr2,chr3"
+        val nonEmptySetA = newSplitter(nonEmptyStringA)
+        assertEquals(3, nonEmptySetA.size)
+        assertTrue(nonEmptySetA.contains("chr1"))
+        assertTrue(nonEmptySetA.contains("chr2"))
+        assertTrue(nonEmptySetA.contains("chr3"))
+
+        // Test with actual contigs (B)
+        val nonEmpytStringB = "chr1, chr2, chrA,CHRX,   CHR21A,       htg234a"
+        val nonEmptySetB = newSplitter(nonEmpytStringB)
+        assertEquals(6, nonEmptySetB.size)
+        assertTrue(nonEmptySetB.contains("chr1"))
+        assertTrue(nonEmptySetB.contains("chr2"))
+        assertTrue(nonEmptySetB.contains("chrA"))
+        assertTrue(nonEmptySetB.contains("CHRX"))
+        assertTrue(nonEmptySetB.contains("CHR21A"))
+        assertTrue(nonEmptySetB.contains("htg234a"))
     }
 }


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description
* Fixes `--contig-list` flag issue when no contig IDs are passed. Originally, if default value was specified (`""`), this would cause no spline knots to be generated for any contig ID as opposed to the expected result where all positional knots for all IDs should be generated.



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Fixes default "--contig-list" exception where no IDs would be returned
```