### PR TITLE
Initial fix for diploid to haploid bug

### DIFF
--- a/data/test/hvcf2vcf/asmHvcfs/hvcf_files_with_missing/LineAB_diploid_missing.h.vcf
+++ b/data/test/hvcf2vcf/asmHvcfs/hvcf_files_with_missing/LineAB_diploid_missing.h.vcf
@@ -1,0 +1,39 @@
+##fileformat=VCFv4.2
+##ALT=<ID=12f0cec9102e84a161866e37072443b7,Description="haplotype data for line: LineA",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineA,Regions=1:1-1000,Checksum=12f0cec9102e84a161866e37072443b7,RefRange=1:1-1000,RefChecksum=546d1839623a5b0ea98bbff9a8a320e2>
+##ALT=<ID=1b568197f6f329ec5b71f66e49a732fb,Description="haplotype data for line: LineA",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineA,Regions=1:5501-6500,Checksum=1b568197f6f329ec5b71f66e49a732fb,RefRange=1:5501-6500,RefChecksum=d896e9cc56e74f39fd3f3c665191d727>
+##ALT=<ID=3149b3144f93134eb29661bade697fc6,Description="haplotype data for line: LineA",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineA,Regions=1:1001-5500,Checksum=3149b3144f93134eb29661bade697fc6,RefRange=1:1001-5500,RefChecksum=57705b1e2541c7634ea59a48fc52026f>
+##ALT=<ID=3ec680649615da0685b8c245e0f196e2,Description="haplotype data for line: LineA",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineA,Regions=2:11001-12000,Checksum=3ec680649615da0685b8c245e0f196e2,RefRange=2:11001-12000,RefChecksum=347f0478b1a553ef107243cb60a9ba7d>
+##ALT=<ID=c472bb8d63e19218a4089821ae666db3,Description="haplotype data for line: LineA",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineA,Regions=2:6501-11000,Checksum=c472bb8d63e19218a4089821ae666db3,RefRange=2:6501-11000,RefChecksum=b8843efbd6adaa261a01518dc2a39aa2>
+##ALT=<ID=8f7de1a693aa15fb8fb7b85e7a8b5e95,Description="haplotype data for line: LineB",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineB,Regions=1:6501-11000,Checksum=8f7de1a693aa15fb8fb7b85e7a8b5e95,RefRange=1:6501-11000,RefChecksum=66465399052d8ebe48b06329c60fee03>
+##ALT=<ID=6b5f46bd5c31917af3ab6c3ccc8668cd,Description="haplotype data for line: LineB",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineB,Regions=1:11001-12000,Checksum=6b5f46bd5c31917af3ab6c3ccc8668cd,RefRange=1:11001-12000,RefChecksum=2b4590f722ef9229c15d29e0b4e51a0e>
+##ALT=<ID=aff71f19de448514a6d9208b1fcb4e8a,Description="haplotype data for line: LineB",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineB,Regions=1:12001-16500,Checksum=aff71f19de448514a6d9208b1fcb4e8a,RefRange=1:12001-16500,RefChecksum=f2a26406aaa6aefdc20ccdf8cb313dff>
+##ALT=<ID=180417a01edbfed525d7c238910e0ff4,Description="haplotype data for line: LineB",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineB,Regions=2:1-1000,Checksum=180417a01edbfed525d7c238910e0ff4,RefRange=2:1-1000,RefChecksum=5812acb1aff74866003656316c4539a6>
+##ALT=<ID=8bcf66e8c49da2d9ad8cbafa0bb7a93d,Description="haplotype data for line: LineB",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineB,Regions=2:1001-5500,Checksum=8bcf66e8c49da2d9ad8cbafa0bb7a93d,RefRange=2:1001-5500,RefChecksum=799371fe289fbe0046797729659cb5ff>
+##ALT=<ID=45b121547c7ae517a181fdd2621495c4,Description="haplotype data for line: LineB",Source="/Users/tmc46/temp/phgv2Tests/tempDir/testTileDBURI//assemblies.agc",SampleName=LineB,Regions=2:5501-6500,Checksum=45b121547c7ae517a181fdd2621495c4,RefRange=2:5501-6500,RefChecksum=bbc9274ac9c98fd0f9399ec8f121b9d0>
+##FORMAT=<ID=AD,Number=3,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth (only filtered reads used for calling)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##INFO=<ID=AF,Number=3,Type=Integer,Description="Allele Frequency">
+##INFO=<ID=ASM_Chr,Number=1,Type=String,Description="Assembly chromosome">
+##INFO=<ID=ASM_End,Number=1,Type=Integer,Description="Assembly end position">
+##INFO=<ID=ASM_Start,Number=1,Type=Integer,Description="Assembly start position">
+##INFO=<ID=ASM_Strand,Number=1,Type=String,Description="Assembly strand">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##contig=<ID=1,length=55000>
+##contig=<ID=2,length=55000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	LineAB_diploid
+1	1	.	G	<12f0cec9102e84a161866e37072443b7>	.	.	END=1000	GT	1|1
+1	1001	.	A	<3149b3144f93134eb29661bade697fc6>	.	.	END=5500	GT	.|1
+1	5501	.	A	<1b568197f6f329ec5b71f66e49a732fb>,<05efe15d97db33185b64821791b01b0f>	.	.	END=6500	GT	.|2
+1	6501	.	C	<369464a8743d2e40ad83d1375c196bdd>,<8f7de1a693aa15fb8fb7b85e7a8b5e95>	.	.	END=11000	GT	1|2
+1	11001	.	A	<6b5f46bd5c31917af3ab6c3ccc8668cd>	.	.	END=12000	GT	1|1
+1	12001	.	A	<aff71f19de448514a6d9208b1fcb4e8a>	.	.	END=16500	GT	1|1
+2	1	.	C	<180417a01edbfed525d7c238910e0ff4>	.	.	END=1000	GT	1|1
+2	1001	.	A	<8bcf66e8c49da2d9ad8cbafa0bb7a93d>	.	.	END=5500	GT	1|1
+2	5501	.	G	<50044914d5111c5b5ec58c9d720e3b2d>,<45b121547c7ae517a181fdd2621495c4>	.	.	END=6500	GT	2|1
+2	6501	.	A	<c472bb8d63e19218a4089821ae666db3>,<bc94073196b0b2c13e62b5fa47c76b51>	.	.	END=11000	GT	2|1
+2	11001	.	A	<3ec680649615da0685b8c245e0f196e2>	.	.	END=12000	GT	1|1

--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/Hvcf2Vcf.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/Hvcf2Vcf.kt
@@ -129,7 +129,7 @@ class Hvcf2Vcf:
 
             //walk through each sample and convert to a pair Allele, sampleGamete
             genotype.alleles.mapIndexed { index, allele ->
-                val cleanedAllele = allele.displayString.removeSurrounding("<", ">")
+                val cleanedAllele = if(allele == Allele.NO_CALL) "MISSING" else allele.displayString.removeSurrounding("<", ">")
                 Pair(cleanedAllele, SampleGamete(baseSampleName, index))
             }
         }
@@ -286,6 +286,9 @@ class Hvcf2Vcf:
 
         val hapIdsSeen = mutableSetOf<String>()
 
+        //Get out the missing sampleGametes
+        val missingGametes = refRangeAndHapIdMap[Pair(refRange,"MISSING")]?.map { Pair(it,Allele.NO_CALL) } ?: emptyList()
+
         return vcfContext.genotypes.flatMap { genotype ->
             val sampleName = genotype.sampleName
             //We need to check to see if the asmHapIdMap has the key.  If not we can skip it but should throw an error
@@ -314,7 +317,7 @@ class Hvcf2Vcf:
             sampleGametesForThisHapId.map { sampleGamete ->
                 Pair(sampleGamete, genotype.getAllele(0)) // This should work correctly as the ASM VCF is haploid
             }
-        }
+        } + missingGametes
     }
 
 }

--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/Hvcf2Vcf.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/Hvcf2Vcf.kt
@@ -51,6 +51,8 @@ class Hvcf2Vcf:
         .required()
 
 
+    val MISSING_STRING = "MISSING"
+
     override fun run() {
         processHVCFAndBuildVCF(dbPath, hvcfDir, pangenomeVcfFile, outputFile, referenceFile)
     }
@@ -129,7 +131,7 @@ class Hvcf2Vcf:
 
             //walk through each sample and convert to a pair Allele, sampleGamete
             genotype.alleles.mapIndexed { index, allele ->
-                val cleanedAllele = if(allele == Allele.NO_CALL) "MISSING" else allele.displayString.removeSurrounding("<", ">")
+                val cleanedAllele = if(allele == Allele.NO_CALL) MISSING_STRING else allele.displayString.removeSurrounding("<", ">")
                 Pair(cleanedAllele, SampleGamete(baseSampleName, index))
             }
         }
@@ -287,7 +289,7 @@ class Hvcf2Vcf:
         val hapIdsSeen = mutableSetOf<String>()
 
         //Get out the missing sampleGametes
-        val missingGametes = refRangeAndHapIdMap[Pair(refRange,"MISSING")]?.map { Pair(it,Allele.NO_CALL) } ?: emptyList()
+        val missingGametes = refRangeAndHapIdMap[Pair(refRange,MISSING_STRING)]?.map { Pair(it,Allele.NO_CALL) } ?: emptyList()
 
         return vcfContext.genotypes.flatMap { genotype ->
             val sampleName = genotype.sampleName

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/Hvcf2VcfTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/Hvcf2VcfTest.kt
@@ -178,7 +178,6 @@ class Hvcf2VcfTest {
         val truthMap = buildMissingMap()
 
         for((key,rangeValue) in hvcfRangeValues) {
-            println("${key}\t${rangeValue}")
             assertTrue(truthMap.containsKey(key))
             assertEquals(truthMap.getValue(key).sorted(), rangeValue.sorted())
         }

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/Hvcf2VcfTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/Hvcf2VcfTest.kt
@@ -155,7 +155,7 @@ class Hvcf2VcfTest {
     fun createRangeHapMapToSampleGameteTest() {
         val hvcf2Vcf = Hvcf2Vcf()
 
-        val hvcfDir = "data/test/hvcf2vcf/hvcf_files/"
+        val hvcfDir = "data/test/hvcf2vcf/asmHvcfs/hvcf_files/"
 
         val hvcfRangeValues = hvcf2Vcf.createRangeHapMapToSampleGamete(hvcfDir)
 
@@ -163,7 +163,20 @@ class Hvcf2VcfTest {
 
         for((key,rangeValue) in hvcfRangeValues) {
             assertTrue(truthOutput.containsKey(key))
-            assertEquals(truthOutput.getValue(key), rangeValue)
+            assertEquals(truthOutput.getValue(key).sorted(), rangeValue.sorted())
+        }
+    }
+
+    @Test
+    fun createRangeHapMapToSampleGameteWithMissingTest() {
+        val hvcf2Vcf = Hvcf2Vcf()
+
+        val hvcfDir = "data/test/hvcf2vcf/asmHvcfs/hvcf_files_with_missing/"
+
+        val hvcfRangeValues = hvcf2Vcf.createRangeHapMapToSampleGamete(hvcfDir)
+
+        for((key,rangeValue) in hvcfRangeValues) {
+            println("${key}\t${rangeValue}")
         }
     }
 
@@ -186,17 +199,17 @@ class Hvcf2VcfTest {
 
     fun buildTruthHVCFRecords(): Set<HvcfRangeHapIdSampleGamete> {
         return setOf(
-            HvcfRangeHapIdSampleGamete(ReferenceRange("1",1,1000),"12f0cec9102e84a161866e37072443b7",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("1",1001,5500),"3149b3144f93134eb29661bade697fc6",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("1",5501,6500),"1b568197f6f329ec5b71f66e49a732fb",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("1",6501,11000),"369464a8743d2e40ad83d1375c196bdd",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("1",11001,12000),"f50fe6d6b3d9a9d305889db977969916",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("1",12001,16500),"d4c8b5505d7046b41d7f69b246063ebb",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("2",1,1000),"13417ecbb38b9a159e3ca8c9dade7088",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("2",1001,5500),"c16ac825052c0456069f6408652aadf8",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("2",5501,6500),"50044914d5111c5b5ec58c9d720e3b2d",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("2",6501,11000),"c472bb8d63e19218a4089821ae666db3",  listOf(SampleGamete("LineA", 0))),
-            HvcfRangeHapIdSampleGamete(ReferenceRange("2",11001,12000),"3ec680649615da0685b8c245e0f196e2",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",1,1000),"12f0cec9102e84a161866e37072443b7",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",1001,5500),"3149b3144f93134eb29661bade697fc6",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",5501,6500),"1b568197f6f329ec5b71f66e49a732fb",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",6501,11000),"369464a8743d2e40ad83d1375c196bdd",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",11001,12000),"f50fe6d6b3d9a9d305889db977969916",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",12001,16500),"d4c8b5505d7046b41d7f69b246063ebb",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",1,1000),"13417ecbb38b9a159e3ca8c9dade7088",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",1001,5500),"c16ac825052c0456069f6408652aadf8",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",5501,6500),"50044914d5111c5b5ec58c9d720e3b2d",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",6501,11000),"c472bb8d63e19218a4089821ae666db3",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",11001,12000),"3ec680649615da0685b8c245e0f196e2",  listOf(SampleGamete("LineA", 0), SampleGamete("LineA2", 0))),
             HvcfRangeHapIdSampleGamete(ReferenceRange("1",1,1000), "4fc7b8af32ddd74e07cb49d147ef1938", listOf(SampleGamete("LineB", 0))),
             HvcfRangeHapIdSampleGamete(ReferenceRange("1",1001,5500), "8967fabf10e55d881caa6fe192e7d4ca", listOf(SampleGamete("LineB", 0))),
             HvcfRangeHapIdSampleGamete(ReferenceRange("1",5501,6500), "05efe15d97db33185b64821791b01b0f", listOf(SampleGamete("LineB", 0))),

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/Hvcf2VcfTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/Hvcf2VcfTest.kt
@@ -175,9 +175,40 @@ class Hvcf2VcfTest {
 
         val hvcfRangeValues = hvcf2Vcf.createRangeHapMapToSampleGamete(hvcfDir)
 
+        val truthMap = buildMissingMap()
+
         for((key,rangeValue) in hvcfRangeValues) {
             println("${key}\t${rangeValue}")
+            assertTrue(truthMap.containsKey(key))
+            assertEquals(truthMap.getValue(key).sorted(), rangeValue.sorted())
         }
+    }
+
+    fun buildMissingMap(): Map<Pair<ReferenceRange, String>, List<SampleGamete>> {
+        val gamete1 = SampleGamete("LineAB_diploid", 0)
+        val gamete2 = SampleGamete("LineAB_diploid", 1)
+
+        val bothList = listOf(gamete1, gamete2)
+        val gamete1List = listOf(gamete1)
+        val gamete2List = listOf(gamete2)
+        return mapOf(
+            Pair(ReferenceRange("1",1,1000), "12f0cec9102e84a161866e37072443b7" ) to bothList,
+            Pair(ReferenceRange("1",1001,5500), "MISSING") to gamete1List,
+            Pair(ReferenceRange("1",1001,5500), "3149b3144f93134eb29661bade697fc6") to gamete2List,
+            Pair(ReferenceRange("1",5501,6500), "MISSING") to gamete1List,
+            Pair(ReferenceRange("1",5501,6500), "05efe15d97db33185b64821791b01b0f") to gamete2List,
+            Pair(ReferenceRange("1",6501,11000), "369464a8743d2e40ad83d1375c196bdd") to gamete1List,
+            Pair(ReferenceRange("1",6501,11000), "8f7de1a693aa15fb8fb7b85e7a8b5e95") to gamete2List,
+            Pair(ReferenceRange("1",11001,12000), "6b5f46bd5c31917af3ab6c3ccc8668cd") to bothList,
+            Pair(ReferenceRange("1",12001,16500), "aff71f19de448514a6d9208b1fcb4e8a") to bothList,
+            Pair(ReferenceRange("2", 1, 1000), "180417a01edbfed525d7c238910e0ff4" ) to bothList,
+            Pair(ReferenceRange("2",1001, 5500), "8bcf66e8c49da2d9ad8cbafa0bb7a93d") to bothList,
+            Pair(ReferenceRange("2", 5501, 6500), "45b121547c7ae517a181fdd2621495c4") to gamete1List,
+            Pair(ReferenceRange("2", 5501, 6500), "50044914d5111c5b5ec58c9d720e3b2d") to gamete2List,
+            Pair(ReferenceRange("2", 6501, 11000), "bc94073196b0b2c13e62b5fa47c76b51") to gamete1List,
+            Pair(ReferenceRange("2", 6501, 11000), "c472bb8d63e19218a4089821ae666db3") to gamete2List,
+            Pair(ReferenceRange("2", 11001, 12000), "3ec680649615da0685b8c245e0f196e2") to bothList
+            )
     }
 
 
@@ -190,11 +221,27 @@ class Hvcf2VcfTest {
 
         val hvcfRangeValues = hvcf2Vcf.processSingleHvcfFile(File(inputHvcf))
 
-        val truthOutput = buildTruthHVCFRecords()
+        val truthOutput = buildTruthHVCFRecordsLineA()
 
         for(range in hvcfRangeValues) {
             assertTrue(truthOutput.contains(range))
         }
+    }
+
+    fun buildTruthHVCFRecordsLineA(): Set<HvcfRangeHapIdSampleGamete> {
+        return setOf(
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",1,1000),"12f0cec9102e84a161866e37072443b7",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",1001,5500),"3149b3144f93134eb29661bade697fc6",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",5501,6500),"1b568197f6f329ec5b71f66e49a732fb",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",6501,11000),"369464a8743d2e40ad83d1375c196bdd",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",11001,12000),"f50fe6d6b3d9a9d305889db977969916",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("1",12001,16500),"d4c8b5505d7046b41d7f69b246063ebb",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",1,1000),"13417ecbb38b9a159e3ca8c9dade7088",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",1001,5500),"c16ac825052c0456069f6408652aadf8",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",5501,6500),"50044914d5111c5b5ec58c9d720e3b2d",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",6501,11000),"c472bb8d63e19218a4089821ae666db3",  listOf(SampleGamete("LineA", 0))),
+            HvcfRangeHapIdSampleGamete(ReferenceRange("2",11001,12000),"3ec680649615da0685b8c245e0f196e2",  listOf(SampleGamete("LineA", 0))),
+        )
     }
 
     fun buildTruthHVCFRecords(): Set<HvcfRangeHapIdSampleGamete> {


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

Fixing HVCF to vcf diploid bug where it turned diploids into haploids if one of the haploids were missing.



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Updating hvcf2vcf to better handle diploid vcfs when having missing haplotypes.
```