### PR TITLE
Improve `setup-environment` error handling and diagnostics

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/cli/SetupEnvironment.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/cli/SetupEnvironment.kt
@@ -25,6 +25,57 @@ class SetupEnvironment : CliktCommand(help = "Create a conda environment for PHG
         PHG, TILEDB
     }
 
+    companion object {
+        internal fun condaEnvironmentName(envType: CONDAENVTYPE): String = when (envType) {
+            CONDAENVTYPE.PHG -> "phgv2-conda"
+            CONDAENVTYPE.TILEDB -> "phgv2-tiledb"
+        }
+
+        internal fun isExistingEnvironmentFailure(
+            errorLines: List<String>,
+            outputLines: List<String>
+        ): Boolean {
+            val combinedLines = errorLines + outputLines
+            return combinedLines.any {
+                it.contains("prefix already exists", ignoreCase = true) ||
+                    it.contains("environment already exists", ignoreCase = true)
+            }
+        }
+
+        internal fun summarizeCondaFailure(
+            errorLines: List<String>,
+            outputLines: List<String>,
+            errorLogPath: String
+        ): String {
+            return errorLines.firstOrNull { it.isNotBlank() }
+                ?: outputLines.firstOrNull { it.isNotBlank() }
+                ?: "No conda output captured. See $errorLogPath for details."
+        }
+
+        internal fun isTermsOfServiceFailure(
+            errorLines: List<String>,
+            outputLines: List<String>
+        ): Boolean {
+            val combinedLines = errorLines + outputLines
+            return combinedLines.any {
+                it.contains("CondaToSNonInteractiveError", ignoreCase = true) ||
+                    it.contains("Terms of Service have not been accepted", ignoreCase = true)
+            }
+        }
+
+        internal fun termsOfServiceHelpMessage(): String {
+            return buildString {
+                appendLine("Conda is blocking access because channel Terms of Service have not been accepted.")
+                appendLine("Accept the ToS for the required channels, then rerun setup-environment.")
+                appendLine("Typical commands are:")
+                appendLine("  conda tos accept")
+                appendLine("  conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main")
+                appendLine("  conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r")
+                append("For CI or other non-interactive environments, you can also set CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes.")
+            }
+        }
+    }
+
     val envFile by option("-e", "--env-file", help = "File containing the conda environment definition")
         .default("")
 
@@ -69,11 +120,11 @@ class SetupEnvironment : CliktCommand(help = "Create a conda environment for PHG
             tiledbFile
         }
 
-        runCondaCreate(resultEnvFile, outputDir, envFile, CONDAENVTYPE.PHG)
-        runCondaCreate(tiledbEnvFile, outputDir, tiledbFile, CONDAENVTYPE.TILEDB)
+        runCondaCreate(resultEnvFile, outputDir, CONDAENVTYPE.PHG)
+        runCondaCreate(tiledbEnvFile, outputDir, CONDAENVTYPE.TILEDB)
     }
 
-    private fun runCondaCreate(resultEnvFile: String, outputDir: String, envFile: String, envType: CONDAENVTYPE) {
+    private fun runCondaCreate(resultEnvFile: String, outputDir: String, envType: CONDAENVTYPE) {
         // call ProcessBuilder to execute the conda create env command
         myLogger.info("Creating conda environment from file: $resultEnvFile")
         val builder = ProcessBuilder("conda", "env", "create", "--solver=libmamba", "--file", resultEnvFile)
@@ -94,19 +145,42 @@ class SetupEnvironment : CliktCommand(help = "Create a conda environment for PHG
         val error = process.waitFor()
 
         if (error != 0) {
-            val errorLines = File(redirectError).readLines()
-            val success = errorLines
-                .filter { it.contains("prefix already exists") }
-                .toList()
-            if (success.isEmpty()) {
-                myLogger.error("conda env create command for file ${envFile} run via ProcessBuilder returned error code $error")
-                println("Verify you have conda installed and the environment phgv2-conda does not already exist")
-                throw IllegalStateException("SetupEnvironment: create conda envirionment failed: $error")
+            val errorLines = File(redirectError).takeIf { it.exists() }?.readLines() ?: emptyList()
+            val outputLines = File(redirectOutput).takeIf { it.exists() }?.readLines() ?: emptyList()
+            val envName = condaEnvironmentName(envType)
+
+            if (!isExistingEnvironmentFailure(errorLines, outputLines)) {
+                val failureSummary = summarizeCondaFailure(errorLines, outputLines, redirectError)
+                val tosHelp = if (isTermsOfServiceFailure(errorLines, outputLines)) {
+                    "\n${termsOfServiceHelpMessage()}"
+                } else {
+                    ""
+                }
+                myLogger.error(
+                    "conda env create command for file $resultEnvFile returned error code $error. " +
+                        "See $redirectError for details. First message: $failureSummary$tosHelp"
+                )
+                println("Conda environment creation failed for $resultEnvFile.")
+                println("See $redirectError for details.")
+                if (isTermsOfServiceFailure(errorLines, outputLines)) {
+                    println(termsOfServiceHelpMessage())
+                }
+                throw IllegalStateException(
+                    "SetupEnvironment: create conda environment failed for $resultEnvFile " +
+                        "with exit code $error. $failureSummary$tosHelp"
+                )
             } else {
-                myLogger.info("\nThe phgv2-conda conda environment already exists.  You can activate it with the command: conda activate phgv2-conda\n")
+                myLogger.info(
+                    "\nThe $envName conda environment already exists.  " +
+                        "You can activate it with the command: conda activate $envName\n"
+                )
             }
         } else {
-            myLogger.info("Successfully created your environment.  You can activate it with the command: conda activate phgv2-conda")
+            val envName = condaEnvironmentName(envType)
+            myLogger.info(
+                "Successfully created your environment.  " +
+                    "You can activate it with the command: conda activate $envName"
+            )
         }
     }
 

--- a/src/test/kotlin/net/maizegenetics/phgv2/cli/SetupEnvironmentTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/cli/SetupEnvironmentTest.kt
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class SetupEnvironmentTest {
 
@@ -77,6 +80,68 @@ class SetupEnvironmentTest {
         }
         assert(exceptionThrow)
 
+    }
+
+    @Test
+    fun testExistingEnvironmentFailureDetectedFromStderr() {
+        val isExistingEnvFailure = SetupEnvironment.isExistingEnvironmentFailure(
+            listOf("CondaValueError: prefix already exists: /tmp/phgv2-conda"),
+            emptyList()
+        )
+
+        assertTrue(isExistingEnvFailure)
+    }
+
+    @Test
+    fun testExistingEnvironmentFailureIsFalseForOtherCondaErrors() {
+        val isExistingEnvFailure = SetupEnvironment.isExistingEnvironmentFailure(
+            listOf("PackagesNotFoundError: The following packages are not available from current channels:"),
+            emptyList()
+        )
+
+        assertFalse(isExistingEnvFailure)
+    }
+
+    @Test
+    fun testSummarizeCondaFailurePrefersStderr() {
+        val summary = SetupEnvironment.summarizeCondaFailure(
+            listOf("PackagesNotFoundError: anchorwave=1.2.5"),
+            listOf("Collecting package metadata"),
+            "/tmp/condaCreate_error.log"
+        )
+
+        assertEquals("PackagesNotFoundError: anchorwave=1.2.5", summary)
+    }
+
+    @Test
+    fun testTermsOfServiceFailureDetectedFromStderr() {
+        val isTermsOfServiceFailure = SetupEnvironment.isTermsOfServiceFailure(
+            listOf("CondaToSNonInteractiveError: Terms of Service have not been accepted"),
+            emptyList()
+        )
+
+        assertTrue(isTermsOfServiceFailure)
+    }
+
+    @Test
+    fun testTermsOfServiceHelpMessageContainsExpectedCommands() {
+        val helpMessage = SetupEnvironment.termsOfServiceHelpMessage()
+
+        assertTrue(helpMessage.contains("conda tos accept"))
+        assertTrue(helpMessage.contains("https://repo.anaconda.com/pkgs/main"))
+        assertTrue(helpMessage.contains("CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes"))
+    }
+
+    @Test
+    fun testCondaEnvironmentNamesMatchExpectedValues() {
+        assertEquals(
+            "phgv2-conda",
+            SetupEnvironment.condaEnvironmentName(SetupEnvironment.CONDAENVTYPE.PHG)
+        )
+        assertEquals(
+            "phgv2-tiledb",
+            SetupEnvironment.condaEnvironmentName(SetupEnvironment.CONDAENVTYPE.TILEDB)
+        )
     }
 
 }


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

* Reads both stderr and stdout from the redirected log files and surfaces the first non-blank line in the thrown exception and the user-facing output, along with the path to the full log.
* Detects `CondaToSNonInteractiveError` / "Terms of Service have not been accepted" and prints a concrete remediation message with the relevant `conda tos accept` commands and the `CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes` environment variable for non-interactive use.
* Uses the correct environment name (`phgv2-conda` vs. `phgv2-tiledb`) in all success, "already exists", and failure messages.
* Refactors the failure-classification logic into pure helper functions on a `companion object` so they can be unit-tested without invoking `conda`.
* Adds new unit tests covering the new helpers.

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Improved `setup-environment` error reporting: surfaces the underlying conda failure message, detects Conda Terms-of-Service errors with remediation guidance, and uses the correct environment name (`phgv2-conda` vs. `phgv2-tiledb`) in log output.
```