### PR TITLE
Reads mapping multiple ranges

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
@@ -70,7 +70,7 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
         .int()
         .default(70)
 
-    val minSingleRange by option(help = "Minimum proportion of read mappings to a single range. " +
+    val minSingleRange by option(help = "Minimum proportion of reads mapping to a single range. " +
             "By default reads mapping to more than one range will not be used. Value must be between 0.0 and 1.0. (Default = 1.0)")
         .double()
         .default(1.0)

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
@@ -9,6 +9,8 @@ import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.validate
+import com.github.ajalt.clikt.parameters.types.double
 import com.github.ajalt.clikt.parameters.types.int
 import net.maizegenetics.phgv2.api.HaplotypeGraph
 import net.maizegenetics.phgv2.api.ReferenceRange
@@ -19,6 +21,7 @@ import net.maizegenetics.phgv2.pathing.ReadInputFile
 import org.apache.logging.log4j.LogManager
 import java.io.BufferedReader
 import java.io.InputStreamReader
+import kotlin.collections.contains
 
 
 /**
@@ -67,6 +70,12 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
     val minEnd by option(help = "Minimum end position for a read to be considered a match. Any alignments with an end below this will be ignored.")
         .int()
         .default(70)
+
+    val minSingleRange by option(help = "Minimum proportion of read mappings to a single range. " +
+            "By default reads mapping to more than one range will not be used. Value must be between 0.0 and 1.0. (Default = 1.0)")
+        .double()
+        .default(1.0)
+        .validate { require((it in 0.0..1.0) ) { "value must be between 0.0 and 1.0 but was $it" } }
 
 
     override fun run() {
@@ -183,7 +192,6 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
         return readMapping
     }
 
-
     /**
      * Function to process the mems for a single read and add them to the readMapping
      * This will filter things based on the maxStart and minEnd positions, then  maxNumHits and retain the mems that are longest
@@ -199,36 +207,37 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
         val maxLength = posFilteredMems.maxOf { it.readEnd - it.readStart }
         //remove any hits that are not the longest
         val bestHits = posFilteredMems.filter { it.readEnd - it.readStart == maxLength }
-
         val totalNumHits = bestHits.sumOf { it.numHits }
+        val bestHapIds = bestHits.flatMap { it.listMemHits.map{hits -> hits.contig} }.toSet()
 
         if(totalNumHits <= maxNumHits) {
-            //if the total number of hits is less than the maxNumHits, Filter the haps down to a single ref range and then add all those to the readMapping
-            //First turn the hapIds into a set then back to a list and sort so it will be consistent
-            val bestHapIds = bestHits.flatMap { it.listMemHits.map{hits -> hits.contig} }.toSet()
+            //count the number hapids per reference range
+            //note that this is not the number of genomes matched in a reference range
+            //the number of genomes could be greater if genomes share hapids
+            //the number of hapids is easier to calculate and serves the same purpose, which is to limit the number of
+            //matches to multiple reference ranges
+            val refRangeCounts = bestHapIds.map { hapIdToRefRangeMap[it] }
+                .filterNotNull()
+                .flatten()
+                .groupingBy { it }
+                .eachCount()
+            val maxRefRangeCount = refRangeCounts.maxOf { it.value }
+            val totalRefRangeCount = refRangeCounts.values.sum()
 
-            val filteredBestHapIds = filterToOneReferenceRange(bestHapIds, hapIdToRefRangeMap)
+            //control how many hits ar allowed to multiple reference ranges
+            if (maxRefRangeCount / totalRefRangeCount >= minSingleRange) {
 
-            val hapIdsHit = filteredBestHapIds.sorted()
-            readMapping[hapIdsHit] = (readMapping[hapIdsHit]?:0) + 1
+                //Next, filter the haps down to a single ref range and then add all those to the readMapping
+                //First turn the hapIds into a set then back to a list and sort so it will be consistent
+                val maxRefRange = refRangeCounts.maxByOrNull { it.value }?.key
+
+                //Then filter out any hapIds that don't have that reference range
+                val filteredBestHapIds =  bestHapIds.filter { hapIdToRefRangeMap[it]?.contains(maxRefRange)?:false }
+                val hapIdsHit = filteredBestHapIds.sorted()
+                readMapping[hapIdsHit] = (readMapping[hapIdsHit]?:0) + 1
+            }
+
         }
-    }
-
-    /**
-     * Function to filter the hapIds to only those that hit a single reference range
-     * This will pick the highest occurring reference range and if there is a tie it will choose the first one.
-     */
-    fun filterToOneReferenceRange(hapIds: Set<String>, hapIdToRefRangeMap: Map<String, List<ReferenceRange>>) : List<String> {
-        //figure out which reference range is hit the most
-        val refRangeCounts = hapIds.map { hapIdToRefRangeMap[it] }
-            .filterNotNull()
-            .flatten()
-            .groupingBy { it }
-            .eachCount()
-
-        val maxRefRange = refRangeCounts.maxByOrNull { it.value }?.key
-        //Then filter out any hapIds that don't have that reference range
-        return hapIds.filter { hapIdToRefRangeMap[it]?.contains(maxRefRange)?:false }
     }
 
     /**

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
@@ -23,7 +23,6 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import kotlin.collections.contains
 
-
 /**
  * MapReads will map read files independently to a pangenome indexed by ropeBWT3
  * This will create a standard read mapping file that can be used for path finding
@@ -89,7 +88,7 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
 
         myLogger.info("Mapping reads to pangenome")
 
-        mapAllReadFiles(index, readInputFiles.getReadFiles(), outputDir, threads, minMemLength, maxNumHits, condaEnvPrefix, hapIdToRefRangeMap, maxStart, minEnd)
+        mapAllReadFiles(index, readInputFiles.getReadFiles(), outputDir, threads, minMemLength, maxNumHits, condaEnvPrefix, hapIdToRefRangeMap, maxStart, minEnd, minSingleRange)
     }
 
     /**
@@ -97,18 +96,18 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
      */
     fun mapAllReadFiles(index: String, keyFileDataEntries: List<KeyFileData>, outputDir: String, threads: Int,
                         minMemLength: Int, maxNumHits: Int, condaEnvPrefix: String,
-                        hapIdToRefRangeMap : Map<String, List<ReferenceRange>>, maxStart: Int, minEnd: Int) {
+                        hapIdToRefRangeMap : Map<String, List<ReferenceRange>>, maxStart: Int, minEnd: Int, minSingleRange: Double) {
         //Loop through the keyFileDataEntries and map the reads
         //If there is a second file it processes that and makes a separate readMapping file.
         val readNameToFileMap = mutableMapOf<String,MutableList<String>>()
         for(readFile in keyFileDataEntries) {
             val fileList = readNameToFileMap[readFile.sampleName]?: mutableListOf()
             val outputFile1 = "$outputDir/${readFile.sampleName}_1_readMapping.txt"
-            mapSingleReadFile(index, readFile.sampleName, readFile.file1,outputFile1, threads, minMemLength, maxNumHits, condaEnvPrefix, hapIdToRefRangeMap, maxStart, minEnd)
+            mapSingleReadFile(index, readFile.sampleName, readFile.file1,outputFile1, threads, minMemLength, maxNumHits, condaEnvPrefix, hapIdToRefRangeMap, maxStart, minEnd, minSingleRange)
             fileList.add(outputFile1)
             if(readFile.file2 != "") {
                 val outputFile2 = "$outputDir/${readFile.sampleName}_2_readMapping.txt"
-                mapSingleReadFile(index, readFile.sampleName, readFile.file2, outputFile2, threads, minMemLength, maxNumHits, condaEnvPrefix, hapIdToRefRangeMap, maxStart, minEnd)
+                mapSingleReadFile(index, readFile.sampleName, readFile.file2, outputFile2, threads, minMemLength, maxNumHits, condaEnvPrefix, hapIdToRefRangeMap, maxStart, minEnd, minSingleRange)
                 fileList.add(outputFile2)
             }
             readNameToFileMap[readFile.sampleName] = fileList
@@ -121,12 +120,12 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
      */
     fun mapSingleReadFile(index: String, sampleName: String,readFile: String, outputFile: String, threads: Int,
                           minMemLength: Int, maxNumHits: Int, condaEnvPrefix: String,
-                          hapIdToRefRangeMap: Map<String,List<ReferenceRange>>, maxStart: Int, minEnd: Int) {
+                          hapIdToRefRangeMap: Map<String,List<ReferenceRange>>, maxStart: Int, minEnd: Int, minSingleRange: Double) {
         myLogger.info("Mapping reads in $readFile to $index")
 
         val bedFileReader = setupMappingProcess(index, readFile, threads, minMemLength, maxNumHits, condaEnvPrefix)
 
-        val readMapping = createReadMappingsForFileReader(bedFileReader, maxNumHits, hapIdToRefRangeMap, maxStart, minEnd)
+        val readMapping = createReadMappingsForFileReader(bedFileReader, maxNumHits, hapIdToRefRangeMap, maxStart, minEnd, minSingleRange)
 
         bedFileReader.close()
 
@@ -165,7 +164,8 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
         maxNumHits: Int,
         hapIdToRefRangeMap: Map<String, List<ReferenceRange>>,
         maxStart: Int,
-        minEnd: Int
+        minEnd: Int,
+        minSingleRange: Double
     ): MutableMap<List<String>, Int> {
         var currentLine = bedFileReader.readLine()
         val tempMems = mutableListOf<MEM>()
@@ -178,7 +178,7 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
             val alignmentParsed = RopeBWTUtils.parseStringIntoMem(currentLine)
             if (tempMems.isNotEmpty() && tempMems[0].readName != alignmentParsed.readName) {
                 //write out the tempMems
-                processMemsForRead(tempMems, readMapping, maxNumHits,hapIdToRefRangeMap, maxStart, minEnd)
+                processMemsForRead(tempMems, readMapping, maxNumHits,hapIdToRefRangeMap, maxStart, minEnd, minSingleRange)
                 tempMems.clear()
             }
             tempMems.add(alignmentParsed)
@@ -186,7 +186,7 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
         }
 
         if(tempMems.isNotEmpty()) {
-            processMemsForRead(tempMems, readMapping, maxNumHits, hapIdToRefRangeMap, maxStart, minEnd)
+            processMemsForRead(tempMems, readMapping, maxNumHits, hapIdToRefRangeMap, maxStart, minEnd, minSingleRange)
         }
 
         return readMapping
@@ -198,7 +198,7 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
      * Because MEMs are Maximal Exact Matches, the longest MEMs are the best hits
      */
     fun processMemsForRead(tempMems: List<MEM>, readMapping: MutableMap<List<String>, Int>, maxNumHits: Int,
-                           hapIdToRefRangeMap: Map<String, List<ReferenceRange>>, maxStart: Int, minEnd: Int) {
+                           hapIdToRefRangeMap: Map<String, List<ReferenceRange>>, maxStart: Int, minEnd: Int, minSingleRange: Double) {
         val posFilteredMems = tempMems.filter { it.readStart <= maxStart && it.readEnd >= minEnd }
         if(posFilteredMems.isEmpty()) {
             return
@@ -216,8 +216,7 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
             //the number of genomes could be greater if genomes share hapids
             //the number of hapids is easier to calculate and serves the same purpose, which is to limit the number of
             //matches to multiple reference ranges
-            val refRangeCounts = bestHapIds.map { hapIdToRefRangeMap[it] }
-                .filterNotNull()
+            val refRangeCounts = bestHapIds.mapNotNull { hapIdToRefRangeMap[it] }
                 .flatten()
                 .groupingBy { it }
                 .eachCount()

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
@@ -71,9 +71,9 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
         .default(70)
 
     val minSingleRange by option(help = "Minimum proportion of reads mapping to a single range. " +
-            "By default reads mapping to more than one range will not be used. Value must be between 0.0 and 1.0. (Default = 1.0)")
+            "Value must be between 0.0 and 1.0. (Default = 0.0)")
         .double()
-        .default(1.0)
+        .default(0.0)
         .validate { require((it in 0.0..1.0) ) { "value must be between 0.0 and 1.0 but was $it" } }
 
 

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReads.kt
@@ -96,7 +96,7 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
      */
     fun mapAllReadFiles(index: String, keyFileDataEntries: List<KeyFileData>, outputDir: String, threads: Int,
                         minMemLength: Int, maxNumHits: Int, condaEnvPrefix: String,
-                        hapIdToRefRangeMap : Map<String, List<ReferenceRange>>, maxStart: Int, minEnd: Int, minSingleRange: Double) {
+                        hapIdToRefRangeMap : Map<String, List<ReferenceRange>>, maxStart: Int, minEnd: Int, minSingleRange: Double = 0.0) {
         //Loop through the keyFileDataEntries and map the reads
         //If there is a second file it processes that and makes a separate readMapping file.
         val readNameToFileMap = mutableMapOf<String,MutableList<String>>()
@@ -224,7 +224,7 @@ class MapReads : CliktCommand(help="Map reads to a pangenome using ropeBWT3") {
             val totalRefRangeCount = refRangeCounts.values.sum()
 
             //control how many hits ar allowed to multiple reference ranges
-            if (maxRefRangeCount / totalRefRangeCount >= minSingleRange) {
+            if (maxRefRangeCount.toDouble() / totalRefRangeCount >= minSingleRange) {
 
                 //Next, filter the haps down to a single ref range and then add all those to the readMapping
                 //First turn the hapIds into a set then back to a list and sort so it will be consistent

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsFromBed.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsFromBed.kt
@@ -47,7 +47,7 @@ class MapReadsFromBed : CliktCommand(help = "Map reads to a ropebwt3 index from 
     val sampleName by option(help = "Sample name to use in the output read mapping file.")
         .required()
 
-    val minSingleRange by option(help = "Minimum proportion of read mappings to a single range. " +
+    val minSingleRange by option(help = "Minimum proportion of reads mapping to a single range. " +
             "By default reads mapping to more than one range will not be used. Value must be between 0.0 and 1.0. (Default = 1.0)")
         .double()
         .default(1.0)

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsFromBed.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsFromBed.kt
@@ -5,6 +5,8 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.validate
+import com.github.ajalt.clikt.parameters.types.double
 import com.github.ajalt.clikt.parameters.types.int
 import net.maizegenetics.phgv2.api.HaplotypeGraph
 import net.maizegenetics.phgv2.cli.logCommand
@@ -45,6 +47,12 @@ class MapReadsFromBed : CliktCommand(help = "Map reads to a ropebwt3 index from 
     val sampleName by option(help = "Sample name to use in the output read mapping file.")
         .required()
 
+    val minSingleRange by option(help = "Minimum proportion of read mappings to a single range. " +
+            "By default reads mapping to more than one range will not be used. Value must be between 0.0 and 1.0. (Default = 1.0)")
+        .double()
+        .default(1.0)
+        .validate { require((it in 0.0..1.0) ) { "value must be between 0.0 and 1.0 but was $it" } }
+
     override fun run() {
         logCommand(this)
 
@@ -58,7 +66,7 @@ class MapReadsFromBed : CliktCommand(help = "Map reads to a ropebwt3 index from 
 
         val mapReads = MapReads()
         val bedFileReader = bufferedReader(bedFile)
-        val readMapping = mapReads.createReadMappingsForFileReader(bedFileReader, maxNumHits, hapIdToRefRangeMap, maxStart, minEnd)
+        val readMapping = mapReads.createReadMappingsForFileReader(bedFileReader, maxNumHits, hapIdToRefRangeMap, maxStart, minEnd, minSingleRange)
 
         bedFileReader.close()
 

--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsFromBed.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsFromBed.kt
@@ -48,9 +48,9 @@ class MapReadsFromBed : CliktCommand(help = "Map reads to a ropebwt3 index from 
         .required()
 
     val minSingleRange by option(help = "Minimum proportion of reads mapping to a single range. " +
-            "By default reads mapping to more than one range will not be used. Value must be between 0.0 and 1.0. (Default = 1.0)")
+            "Value must be between 0.0 and 1.0. (Default = 0.0)")
         .double()
-        .default(1.0)
+        .default(0.0)
         .validate { require((it in 0.0..1.0) ) { "value must be between 0.0 and 1.0 but was $it" } }
 
     override fun run() {

--- a/src/test/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -79,6 +80,12 @@ class MapReadsTest {
         assertEquals(1, noHvcfDir.statusCode)
         assertEquals("Usage: map-reads [<options>]\n\n" +
                 "Error: missing option --hvcf-dir\n", noHvcfDir.stderr)
+
+        val outOfRange = mapReads.test("--min-single-range 2.0 --index testIndex --read-files test1.fq --output-dir testDir --hvcf-dir ${TestExtension.smallSeqInputDir}")
+        assertEquals(1, noOutputDir.statusCode)
+        assertEquals("Usage: map-reads [<options>]\n\n" +
+                "Error: invalid value for --min-single-range: value must be between 0.0 and 1.0 but was 2.0\n", outOfRange.stderr)
+
     }
 
     @Test
@@ -115,21 +122,21 @@ class MapReadsTest {
     fun testProcessMemsForRead() {
         val mapReads = MapReads()
 
-        val hapIdToRefRangeMap = mapOf("hap1" to listOf(ReferenceRange("chr1",100,200)), "hap2" to listOf(ReferenceRange("chr1",100,200)), "hap3" to listOf(ReferenceRange("chr1",100,200)),
+        var hapIdToRefRangeMap = mapOf("hap1" to listOf(ReferenceRange("chr1",100,200)), "hap2" to listOf(ReferenceRange("chr1",100,200)), "hap3" to listOf(ReferenceRange("chr1",100,200)),
             "hap4" to listOf(ReferenceRange("chr1",100,200)), "hap5" to listOf(ReferenceRange("chr1",100,200)))
 
         //Make a simple 1 MEM hit
         val simpleMEMList = listOf(MEM("read1",0,150,3,listOf(MEMHit("hap1", "+", 100), MEMHit("hap2", "-", 200), MEMHit("hap3", "+", 300))))
 
         var simpleReadMapping = mutableMapOf<List<String>, Int>()
-        mapReads.processMemsForRead(simpleMEMList,simpleReadMapping,5, hapIdToRefRangeMap, 0, 150)
+        mapReads.processMemsForRead(simpleMEMList,simpleReadMapping,5, hapIdToRefRangeMap, 0, 150, 1.0)
         assertEquals(1, simpleReadMapping.size)
         assertEquals(listOf("hap1","hap2","hap3"), simpleReadMapping.keys.first())
         assertEquals(1, simpleReadMapping[listOf("hap1","hap2","hap3")])
 
 
         simpleReadMapping = mutableMapOf()
-        mapReads.processMemsForRead(simpleMEMList,simpleReadMapping,2, hapIdToRefRangeMap,0, 150)
+        mapReads.processMemsForRead(simpleMEMList,simpleReadMapping,2, hapIdToRefRangeMap,0, 150, 1.0)
         assertEquals(0, simpleReadMapping.size)
 
 
@@ -146,10 +153,10 @@ class MapReadsTest {
         )
 
         simpleReadMapping = mutableMapOf()
-        mapReads.processMemsForRead(simpleMEMList,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150)
-        mapReads.processMemsForRead(simpleMEMList2,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150)
-        mapReads.processMemsForRead(simpleMEMList3,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150)
-        mapReads.processMemsForRead(simpleMEMList4,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150)
+        mapReads.processMemsForRead(simpleMEMList,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 1.0)
+        mapReads.processMemsForRead(simpleMEMList2,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 1.0)
+        mapReads.processMemsForRead(simpleMEMList3,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 1.0)
+        mapReads.processMemsForRead(simpleMEMList4,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 1.0)
         assertEquals(3, simpleReadMapping.size)
         assertTrue(simpleReadMapping.keys.contains(listOf("hap1","hap2","hap3")))
         assertEquals(2, simpleReadMapping[listOf("hap1","hap2","hap3")])
@@ -162,6 +169,43 @@ class MapReadsTest {
         //pass in empty list
         simpleReadMapping = mutableMapOf()
         assertEquals(0, simpleReadMapping.size)
+
+        //test minSingleRange parameter
+        hapIdToRefRangeMap = mapOf("hap1" to listOf(ReferenceRange("chr1",100,200)), "hap2" to listOf(ReferenceRange("chr1",100,200)), "hap3" to listOf(ReferenceRange("chr1",100,200)),
+            "hap4" to listOf(ReferenceRange("chr2",100,200)), "hap5" to listOf(ReferenceRange("chr2",100,200)))
+
+        simpleReadMapping = mutableMapOf()
+        //simpleMEMList = hap1, hap2, hap3
+        //simpleMEMList2 = hap1, hap2, hap3
+        //simpleMEMList3 = hap1, hap2, hap3
+        //simpleMEMList4 = hap1, hap2, hap3, hap4, hap5
+        //simpleMEMList4 should be rejected but the others accepted when minSingleRange = 1.0
+        mapReads.processMemsForRead(simpleMEMList,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 1.0)
+        mapReads.processMemsForRead(simpleMEMList2,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 1.0)
+        mapReads.processMemsForRead(simpleMEMList3,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 1.0)
+        mapReads.processMemsForRead(simpleMEMList4,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 1.0)
+        assertEquals(2, simpleReadMapping.size)
+        assertTrue(simpleReadMapping.keys.contains(listOf("hap1","hap2","hap3")))
+        assertEquals(2, simpleReadMapping[listOf("hap1","hap2","hap3")])
+        assertTrue(simpleReadMapping.keys.contains(listOf("hap4","hap5")))
+        assertEquals(1, simpleReadMapping[listOf("hap4","hap5")])
+        assertFalse(simpleReadMapping.keys.contains(listOf("hap1","hap2","hap3","hap4","hap5")))
+
+        //all reads should be accepted when minSingleRange = 0.0, but for simpleMEMList4, hap4 and hap5 should be deleted
+        //as a result expect 3 copies of hap1,hap2,hap3 and one of hap4,hap5
+        simpleReadMapping = mutableMapOf()
+        mapReads.processMemsForRead(simpleMEMList,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 0.0)
+        mapReads.processMemsForRead(simpleMEMList2,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 0.0)
+        mapReads.processMemsForRead(simpleMEMList3,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 0.0)
+        mapReads.processMemsForRead(simpleMEMList4,simpleReadMapping,6, hapIdToRefRangeMap, 2, 150, 0.0)
+        assertEquals(2, simpleReadMapping.size)
+        assertTrue(simpleReadMapping.keys.contains(listOf("hap1","hap2","hap3")))
+        assertEquals(3, simpleReadMapping[listOf("hap1","hap2","hap3")])
+        assertTrue(simpleReadMapping.keys.contains(listOf("hap4","hap5")))
+        assertEquals(1, simpleReadMapping[listOf("hap4","hap5")])
+        assertFalse(simpleReadMapping.keys.contains(listOf("hap1","hap2","hap3","hap4","hap5")))
+
+
     }
 
     @Test
@@ -176,7 +220,7 @@ class MapReadsTest {
 
 
         val mapReads = MapReads()
-        val readMapping = mapReads.createReadMappingsForFileReader(reader, 5, hapIdToRefRangeMap, 2, 150)
+        val readMapping = mapReads.createReadMappingsForFileReader(reader, 5, hapIdToRefRangeMap, 2, 150, 1.0)
 
         println(readMapping)
 
@@ -218,7 +262,7 @@ class MapReadsTest {
 
         val hapIdToRefRangeMap = graph.hapIdToRefRangeMap()
 
-        mapReads.mapSingleReadFile(index, "LineA" ,readFile, outputFile ,5, 148, 5, "", hapIdToRefRangeMap, 2, 148)
+        mapReads.mapSingleReadFile(index, "LineA" ,readFile, outputFile ,5, 148, 5, "", hapIdToRefRangeMap, 2, 148, 1.0)
 
         val expectedLines = bufferedReader("data/test/ropebwt/LineA_1_readMapping.txt").readLines()
         val expectedReadMap = expectedLines.filter { !it.startsWith("#") }.filter { !it.startsWith("HapId") }.map { it.split("\t") }.associate { it[0] to it[1].toInt() }
@@ -249,7 +293,7 @@ class MapReadsTest {
         val hapIdToRefRangeMap = graph.hapIdToRefRangeMap()
 
         val keyFileDataEntry = listOf(KeyFileData("LineA", "data/test/kmerReadMapping/simulatedReads/LineA_1.fq", "data/test/kmerReadMapping/simulatedReads/LineA_2.fq"))
-        mapReads.mapAllReadFiles(index, keyFileDataEntry, outputDir, 5, 148, 5, "", hapIdToRefRangeMap, 2, 148)
+        mapReads.mapAllReadFiles(index, keyFileDataEntry, outputDir, 5, 148, 5, "", hapIdToRefRangeMap, 2, 148, 1.0)
 
 
         val expectedLines = bufferedReader("data/test/ropebwt/LineA_1_readMapping.txt").readLines()
@@ -286,33 +330,4 @@ class MapReadsTest {
         expectedLines.indices.forEach { assertEquals(expectedLines[it], observedLines[it]) }
     }
 
-    @Test
-    fun testFilterToOneReferenceRange() {
-        val mapReads = MapReads()
-        val hapIdToRefRangeMap = mapOf("hap1" to listOf(ReferenceRange("chr1",100,200)),
-            "hap2" to listOf(ReferenceRange("chr1",100,200)),
-            "hap3" to listOf(ReferenceRange("chr1",100,200)),
-            "hap4" to listOf(ReferenceRange("chr1",200,300)),
-            "hap5" to listOf(ReferenceRange("chr1",200,300)))
-
-
-
-        //all one refRange
-        val allOneHapIdsSet = setOf("hap1","hap2","hap3")
-        val expectedAllOne = setOf("hap1","hap2","hap3")
-        val filteredAllOne = mapReads.filterToOneReferenceRange(allOneHapIdsSet, hapIdToRefRangeMap)
-        assertEquals(3, filteredAllOne.size)
-        assertTrue(filteredAllOne.toSet().containsAll(expectedAllOne))
-        assertTrue(expectedAllOne.containsAll(filteredAllOne.toSet()))
-        
-
-        val threeVTwo = setOf("hap1","hap2","hap3","hap4","hap5")
-        val expectedThree = setOf("hap1","hap2","hap3")
-        val filteredThree = mapReads.filterToOneReferenceRange(threeVTwo, hapIdToRefRangeMap)
-        assertEquals(3, filteredThree.size)
-        assertTrue(filteredThree.toSet().containsAll(expectedThree))
-        assertTrue(expectedThree.containsAll(filteredThree.toSet()))
-
-
-    }
 }

--- a/src/test/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsTest.kt
@@ -262,7 +262,7 @@ class MapReadsTest {
 
         val hapIdToRefRangeMap = graph.hapIdToRefRangeMap()
 
-        mapReads.mapSingleReadFile(index, "LineA" ,readFile, outputFile ,5, 148, 5, "", hapIdToRefRangeMap, 2, 148, 1.0)
+        mapReads.mapSingleReadFile(index, "LineA" ,readFile, outputFile ,5, 148, 5, "", hapIdToRefRangeMap, 2, 148, 0.0)
 
         val expectedLines = bufferedReader("data/test/ropebwt/LineA_1_readMapping.txt").readLines()
         val expectedReadMap = expectedLines.filter { !it.startsWith("#") }.filter { !it.startsWith("HapId") }.map { it.split("\t") }.associate { it[0] to it[1].toInt() }
@@ -293,7 +293,7 @@ class MapReadsTest {
         val hapIdToRefRangeMap = graph.hapIdToRefRangeMap()
 
         val keyFileDataEntry = listOf(KeyFileData("LineA", "data/test/kmerReadMapping/simulatedReads/LineA_1.fq", "data/test/kmerReadMapping/simulatedReads/LineA_2.fq"))
-        mapReads.mapAllReadFiles(index, keyFileDataEntry, outputDir, 5, 148, 5, "", hapIdToRefRangeMap, 2, 148, 1.0)
+        mapReads.mapAllReadFiles(index, keyFileDataEntry, outputDir, 5, 148, 5, "", hapIdToRefRangeMap, 2, 148, 0.0)
 
 
         val expectedLines = bufferedReader("data/test/ropebwt/LineA_1_readMapping.txt").readLines()

--- a/src/test/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsTest.kt
+++ b/src/test/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/MapReadsTest.kt
@@ -82,7 +82,7 @@ class MapReadsTest {
                 "Error: missing option --hvcf-dir\n", noHvcfDir.stderr)
 
         val outOfRange = mapReads.test("--min-single-range 2.0 --index testIndex --read-files test1.fq --output-dir testDir --hvcf-dir ${TestExtension.smallSeqInputDir}")
-        assertEquals(1, noOutputDir.statusCode)
+        assertEquals(1, outOfRange.statusCode)
         assertEquals("Usage: map-reads [<options>]\n\n" +
                 "Error: invalid value for --min-single-range: value must be between 0.0 and 1.0 but was 2.0\n", outOfRange.stderr)
 


### PR DESCRIPTION
## Description

This pull request modifies MapReads by adding a new parameter, --min-single-range. The values for this parameter can range from 0.0 to 1.0. It is the minimum proportion of mapping hits as reported by ropebwt3 that hit a single range. If one, all hits must come from one range. If 0, then there is no restriction on the minimum number of hits coming from a single range. The value defaults to zero, in which case the is no change to the mapping results.


## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x ] I have performed a self-review of my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

Adds --min-single-range parameter to map-reads, which for each read, determines the minimum proportion of hits that must come from a single reference range.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note

```