### PR TITLE
Add bypass check

### DIFF
--- a/.github/workflows/phgv2_ci_docs.yml
+++ b/.github/workflows/phgv2_ci_docs.yml
@@ -1,0 +1,34 @@
+name: PHGv2 CI Docs Bypass
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+    paths-ignore:
+      - 'src/**'
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      src_changed: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'src/**'
+
+  test:
+    name: PHGv2 CI
+    needs: detect
+    if: ${{ needs.detect.outputs.src_changed == 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: No src changes - pass required check
+        run: echo "No files under src/** changed; passing required PHGv2 CI check."


### PR DESCRIPTION
<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

This PR adds a companion workflow that bypasses the testing suite in the event of no changes to `src/` files (e.g. updating only contents to `docs/` and nothing else). It triggers on PRs to the main branch and leverages [`dorny/paths-filter`](https://github.com/dorny/paths-filter) to detect whether any `src/` files actually changed and **only** emits a passing CI when `src/` files remain untouched. This will be beneficial for users that do not have admin privileges since they cannot bypass the current stalled CI workflow.

On mixed PRs (e.g. modifying `src/` and `docs/`), this workflow's check job is skipped rather than passing, so this should not mask any failing builds.


## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Documentation-only pull requests can now be merged without an admin override, since the required CI check no longer remains blocked when no source code changes.
```