### PR TITLE
Fix log/linear scale error in diploid Viterbi transition

### DIFF
--- a/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/ViterbiHMM.kt
+++ b/src/main/kotlin/net/maizegenetics/phgv2/pathing/ropebwt/ViterbiHMM.kt
@@ -94,7 +94,7 @@ class ViterbiHMM(val inbreedingCoefficient: Double, val sameGameteProbability: D
             for (index2 in 0 until nParents) {
                 for (index3 in 0 until nParents) {
                     for (index4 in 0 until nParents) {
-                        transitionMatrix[ptr++] = transitionProbabilityCalculator.calculate(Pair(index1, index2), Pair(index3, index4))
+                        transitionMatrix[ptr++] = transitionProbabilityCalculator.calculateLn(Pair(index1, index2), Pair(index3, index4))
                     }
                 }
             }
@@ -111,9 +111,9 @@ class ViterbiHMM(val inbreedingCoefficient: Double, val sameGameteProbability: D
         //probability of a specific homozygote = f/nParents heterozygoe = (1-f)/(nParents*nParents - nParents)
         val homozygoteProbabillity = inbreedingCoefficient / nParents
         val heterozygoteProbability = (1.0 - inbreedingCoefficient) / (nParents * nParents - nParents)
-        val initProbs = DoubleArray(nParents * nParents) {heterozygoteProbability}
+        val initProbs = DoubleArray(nParents * nParents) {lnOrFloor(heterozygoteProbability)}
         for (ndx in 0 until nParents) {
-            initProbs[ndx * nParents + ndx] = homozygoteProbabillity
+            initProbs[ndx * nParents + ndx] = lnOrFloor(homozygoteProbabillity)
         }
 
         val result = viterbiOptimized(nStates, nPositions, initProbs,
@@ -129,6 +129,9 @@ class ViterbiHMM(val inbreedingCoefficient: Double, val sameGameteProbability: D
             gameteIndexMap[parentList[i % nParents]] ?: "none")}
         return resultList
     }
+
+    /** ln(p), floored so that p == 0.0 yields a large finite penalty rather than -Inf. */
+    private fun lnOrFloor(p: Double): Double = if (p <= 0.0) -1.0e6 else ln(p)
 
     /**
      * General Viterbi implementation that takes an explicit transition matrix. Used for the diploid


### PR DESCRIPTION
findDiploidPath built its transition matrix with DiploidTransitionProbability.calculate(), which returns raw probabilities, and passed it to viterbiOptimized as the parameter named transitionLogProbabilities. calculateLn() existed but was never called. initProbs had the same defect. The diploid path finder was behaving as a per-position maximum-likelihood classifier with no spatial smoothing.

findHaploidPath is unaffected.

Measured on simulated F1 hybrids at 0.1x (truth is heterozygous at every position, so every genotype switch is a false recombination), diploid, --n-parents 6:

  arm                    switches before -> after    %AB before -> after
  B97xCML103   e=0.001            6,637 ->     0        95.70% -> 100.00%
  B97xCML103   e=0.005           26,739 ->    43        80.75% ->  98.76%
  B73xCML247   e=0.005           29,699 ->    14        83.80% ->  99.89%
  Oh43xIl14H   e=0.005           25,150 ->    77        77.90% ->  98.55%

The bug was apparently introduced around 7/20/2026 as part of the implementation of ImputeBinProbabilities.
Claude-Session: https://claude.ai/code/session_01UxZAcpmfByEYtEvJkmHMzi

<!--
  This template was modified from the PhenoApps/fieldbook pull_request_template.md template.
-->

## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x ] I have performed a self-review of my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing PHG to crash.
- Modified the behavior of the imputation algorithm.
-->

```release-note
Fixed a bug in impute-path-from-ps4g for diploid paths that caused excessive path switching
```